### PR TITLE
collapses the protocol hierarchy a bit, updates docs to match

### DIFF
--- a/Sources/Formic/Documentation.docc/Documentation.md
+++ b/Sources/Formic/Documentation.docc/Documentation.md
@@ -17,7 +17,7 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 
 ### Imperative
 
-- ``Playlist``
+- ``Playbook``
 
 ### Commands
 
@@ -26,7 +26,19 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 - ``CommandOutput``
 - ``CommandError``
 
-### Declarative Resources
+### Resources
 
 - ``OperatingSystem``
-- ``QueryableState``
+- ``DebianPackage``
+
+- ``Resource``
+- ``StatefulResource``
+
+### Singular Resources
+
+- ``SingularResource``
+
+### Collections of Resources
+
+- ``CollectionQueryableResource``
+- ``NamedResource``


### PR DESCRIPTION
## Description
<!--- Provide a summary of your change -->
Simplifies the protocol hierarchy for Resources, removing a level that didn't add any explicit value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have run `./scripts/preflight.bash` and it passed without errors.
