### PR TITLE
Engine stream

### DIFF
--- a/Sources/Formic/Documentation.docc/Documentation.md
+++ b/Sources/Formic/Documentation.docc/Documentation.md
@@ -19,11 +19,16 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 
 - ``Playbook``
 - ``Engine``
+- ``PlaybookStatus``
+- ``PlaybookRunState``
+- ``CommandExecutionResult``
+- ``Verbosity``
 
 ### Commands
 
 - ``Host``
 - ``Command``
+- ``Backoff``
 - ``CommandOutput``
 - ``CommandError``
 

--- a/Sources/Formic/Documentation.docc/Engine.md
+++ b/Sources/Formic/Documentation.docc/Engine.md
@@ -9,12 +9,18 @@
 ### Running Playbooks
 
 - ``schedule(_:delay:startRunner:)``
-- ``status(_:)-2x8yf``
+- ``step(for:)``
 - ``cancel(_:)``
+
+### Receiving Updates from the Engine
+
+- ``commandUpdates``
+- ``playbookUpdates``
+- ``status(_:)``
 
 ### Inspecting the Engine
 
-- ``status(_:)-71oxz``
+- ``runnerOperating(for:)``
 
 ### Controlling the Engine
 

--- a/Sources/Formic/Documentation.docc/Engine.md
+++ b/Sources/Formic/Documentation.docc/Engine.md
@@ -1,0 +1,21 @@
+# ``Engine``
+
+## Topics
+
+### Creating an Engine
+
+- ``init()``
+
+### Running Playbooks
+
+- ``schedule(_:delay:startRunner:)``
+- ``status(_:)-2x8yf``
+- ``cancel(_:)``
+
+### Inspecting the Engine
+
+- ``status(_:)-71oxz``
+
+### Controlling the Engine
+
+- ``cancelRunner(for:)``

--- a/Sources/Formic/Engine/PlaybookRunState.swift
+++ b/Sources/Formic/Engine/PlaybookRunState.swift
@@ -1,13 +1,31 @@
 /// The state of execution for a playbook.
 public enum PlaybookRunState: Sendable, Hashable, Codable {
     /// The playbook is scheduled to run, but hasn't yet started.
-    case scheduled  // initial state
+    ///
+    /// This is the initial state.
+    ///
+    /// A playbook will generally transition to ``running`` once any command from it has been accepted back by the engine.
+    /// A playbook may transition directly to ``failed`` if an exception is thrown while
+    /// running a command.
+    /// It may also transition to ``cancelled`` if it is cancelled using ``Engine/cancel(_:)`` before any commands were run.
+    case scheduled
     /// The playbook is in progress.
+    ///
+    /// The playbook stays in this state until all commands have been run.
+    /// When a command is run that returns a failed, and the command wasn't set to ignore the failure or when an exception, the playbook transitions to ``failed``.
+    /// If all commands are run without any failures to report, the playbook transitions to ``complete``.
     case running
-    /// The playbook is finished.
-    case complete  // terminal state
-    /// The playbook was terminated before completion due to a failed command.
-    case failed  // terminal state
+    /// The playbook is finished without any failed commands.
+    ///
+    /// This is a terminal state.
+    case complete
+    /// The playbook was terminated due to a failed command
+    /// or an exception being thrown while attempting to run a command.
+    ///
+    /// This is a terminal state.
+    case failed
     /// The playbook was terminated before completion due to cancellation.
-    case cancelled  // terminal state
+    ///
+    /// This is a terminal state.
+    case cancelled
 }

--- a/Sources/Formic/Engine/PlaybookStatus.swift
+++ b/Sources/Formic/Engine/PlaybookStatus.swift
@@ -1,6 +1,9 @@
 /// A representation of the state of playbook execution.
 public struct PlaybookStatus: Sendable, Hashable, Codable {
+    /// The state of the playbook.
     public let state: PlaybookRunState
-    public let playbook: Playbook  // would like the name, but the rest is kind of redundant...
+    /// The playbook declaration.
+    public let playbook: Playbook
+    /// A nested dictionary of all results for this playbook, keyed by host, then by command ID.
     public let results: [Host: [Command.ID: CommandExecutionResult]]
 }

--- a/Sources/Formic/Playbook.swift
+++ b/Sources/Formic/Playbook.swift
@@ -41,35 +41,6 @@ public struct Playbook: Identifiable, Sendable {
             }
         }
     }
-
-    /// Runs the playlist synchronously for each host in order, printing out the results.
-    public func runSync() throws {
-        for host in hosts {
-            for command in commands {
-                let result = try command.run(host: host)
-                // TODO: add check to see if Command declaration says to ignore the failure.
-                if result.returnCode != 0 {
-                    // failure
-                    print("❌ \(command) (rc=\(result.returnCode))")
-                    if let stdout = result.stdoutString {
-                        print("  out: \(stdout)")
-                    }
-                    if let stderr = result.stderrString {
-                        print("  out: \(stderr)")
-                    }
-                } else {
-                    // success
-                    print("✅ \(command)")
-                    if let stdout = result.stdoutString {
-                        print("  out: \(stdout)")
-                    }
-                    if let stderr = result.stderrString {
-                        print("  out: \(stderr)")
-                    }
-                }
-            }
-        }
-    }
 }
 
 extension Playbook: Hashable {}

--- a/Tests/formicTests/EngineTests.swift
+++ b/Tests/formicTests/EngineTests.swift
@@ -14,7 +14,7 @@ func initEngine() async throws {
     #expect(await engine.states.isEmpty)
 
     // external/public API
-    #expect(await engine.status(.localhost) == false)
+    #expect(await engine.runnerOperating(for: .localhost) == false)
     #expect(await engine.status(UUID()) == nil)
 
     // internal pieces
@@ -402,7 +402,7 @@ func testPlaybookStateStream() async throws {
         .addSuccess(command: ["uname"], presentOutput: "Linux\n")
         .throwError(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
 
-    let stateStream: AsyncStream<(Playbook.ID, PlaybookRunState)> = engine.playbookStateUpdates
+    let stateStream: AsyncStream<(Playbook.ID, PlaybookRunState)> = engine.playbookUpdates
     var streamIterator = stateStream.makeAsyncIterator()
 
     try await withDependencies { dependencyValues in

--- a/Tests/formicTests/PlaybookTests.swift
+++ b/Tests/formicTests/PlaybookTests.swift
@@ -24,14 +24,14 @@ func testPlaybookSimpleDeclaration() async throws {
 @Test("test playbook creating with hostname resolution")
 func asyncPlaybookInit() async throws {
     typealias IPv4Address = Formic.Host.IPv4Address
-    
+
     let playbook = await withDependencies { dependencyValues in
         dependencyValues.localSystemAccess = TestFileSystemAccess(
             dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
     } operation: {
         await Playbook(name: "basic", hosts: ["somewhere.com"], commands: [])
     }
-    
+
     #expect(playbook.name == "basic")
     #expect(playbook.hosts.count == 1)
     #expect(playbook.hosts[0].networkAddress.address == IPv4Address("8.8.8.8"))


### PR DESCRIPTION
Provides streaming updates of the state of processing for playbooks that are scheduled.

Adds streams for playbook state, and individual commands, to be published as they are processed, either by internal runners for each host, or when the `step(for:)` command is invoked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
