### PR TITLE
enable and test timeout declaration on commands

### DIFF
--- a/Sources/Formic/Command.swift
+++ b/Sources/Formic/Command.swift
@@ -11,8 +11,7 @@ public struct Command: Sendable, Identifiable {
     /// Environment variables the system sets when it runs the command.
     public let env: [String: String]?
     public let ignoreFailure: Bool
-    public let retryOnFailure: Bool
-    public let backoff: Backoff
+    public let retry: RetrySetting
     public let executionTimeout: Duration
     public let id: UUID
 
@@ -30,14 +29,13 @@ public struct Command: Sendable, Identifiable {
 
     private init(
         args: [String], env: [String: String]?, commandType: CommandType, ignoreFailure: Bool,
-        retryOnFailure: Bool, backoff: Backoff, executionTimeout: Duration
+        retry: RetrySetting, executionTimeout: Duration
     ) {
         self.args = args
         self.env = env
         self.commandType = commandType
-        self.retryOnFailure = retryOnFailure
+        self.retry = retry
         self.ignoreFailure = ignoreFailure
-        self.backoff = backoff
         self.executionTimeout = executionTimeout
         id = UUID()
     }
@@ -51,12 +49,12 @@ public struct Command: Sendable, Identifiable {
     ///   - backoff: The strategy used to delay when retrying a failed command.
     /// - Returns: The command declaration.
     public static func shell(
-        _ args: String..., env: [String: String]? = nil, ignoreFailure: Bool = false, retryOnFailure: Bool = false,
-        backoff: Backoff = .default, timeout: Duration = .seconds(30)
+        _ args: String..., env: [String: String]? = nil, ignoreFailure: Bool = false, retry: RetrySetting = .none,
+        timeout: Duration = .seconds(30)
     ) -> Command {
         Command(
-            args: args, env: env, commandType: .shell, ignoreFailure: ignoreFailure, retryOnFailure: retryOnFailure,
-            backoff: backoff, executionTimeout: timeout)
+            args: args, env: env, commandType: .shell, ignoreFailure: ignoreFailure, retry: retry,
+            executionTimeout: timeout)
     }
 
     /// Creates a new command declaration that copies a file to a remote host.
@@ -67,12 +65,12 @@ public struct Command: Sendable, Identifiable {
     ///   - retryOnFailure: A Boolean value that indicates whether the system should retry a failed command.
     ///   - backoff: The strategy used to delay when retrying a failed command.
     public static func remoteCopy(
-        from: String, to: String, ignoreFailure: Bool = false, retryOnFailure: Bool = false,
-        backoff: Backoff = .default, timeout: Duration = .seconds(30)
+        from: String, to: String, ignoreFailure: Bool = false, retry: RetrySetting = .none,
+        timeout: Duration = .seconds(30)
     ) -> Command {
         Command(
-            args: [from, to], env: nil, commandType: .scp, ignoreFailure: ignoreFailure, retryOnFailure: retryOnFailure,
-            backoff: backoff, executionTimeout: timeout)
+            args: [from, to], env: nil, commandType: .scp, ignoreFailure: ignoreFailure, retry: retry,
+            executionTimeout: timeout)
     }
 
     /// Runs the command on the host you provide.

--- a/Sources/Formic/CommandError.swift
+++ b/Sources/Formic/CommandError.swift
@@ -7,6 +7,8 @@ public enum CommandError: LocalizedError {
     case noOutputToParse(msg: String)
     case commandFailed(rc: Int32, errmsg: String)
     case invalidCommand(msg: String)
+    case timeoutExceeded(cmd: Command)
+    case noOutputFromCommand(cmd: Command)
 
     /// The localized description.
     public var errorDescription: String? {
@@ -21,6 +23,10 @@ public enum CommandError: LocalizedError {
             "Command failed with return code \(rc): \(errmsg)"
         case .invalidCommand(let msg):
             "Invalid command: \(msg)"
+        case .timeoutExceeded(let command):
+            "Timeout exceeded for command: \(command)"
+        case .noOutputFromCommand(let cmd):
+            "No output received from command: \(cmd)"
         }
     }
 }

--- a/Sources/Formic/DependencyProxies/CommandInvoker.swift
+++ b/Sources/Formic/DependencyProxies/CommandInvoker.swift
@@ -33,7 +33,7 @@ protocol CommandInvoker: Sendable {
         strictHostKeyChecking: Bool,
         cmd: [String],
         env: [String: String]?
-    ) throws -> CommandOutput
+    ) async throws -> CommandOutput
 
     func remoteCopy(
         host: String,
@@ -43,13 +43,13 @@ protocol CommandInvoker: Sendable {
         strictHostKeyChecking: Bool,
         localPath: String,
         remotePath: String
-    ) throws -> CommandOutput
+    ) async throws -> CommandOutput
 
     func localShell(
         cmd: [String],
         stdIn: Pipe?,
         env: [String: String]?
-    ) throws -> CommandOutput
+    ) async throws -> CommandOutput
 }
 
 // registers the dependency
@@ -82,7 +82,7 @@ struct ProcessCommandInvoker: CommandInvoker {
     /// The types of errors thrown from those locations aren't undocumented.
     func localShell(
         cmd: [String], stdIn: Pipe? = nil, env: [String: String]? = nil
-    ) throws -> CommandOutput {
+    ) async throws -> CommandOutput {
         #if DEBUG
             print("DEBUG!! : \(cmd)")
         #endif
@@ -136,7 +136,7 @@ struct ProcessCommandInvoker: CommandInvoker {
         strictHostKeyChecking: Bool = false,
         localPath: String,
         remotePath: String
-    ) throws -> CommandOutput {
+    ) async throws -> CommandOutput {
         var args: [String] = ["scp"]
 
         if strictHostKeyChecking {
@@ -156,7 +156,7 @@ struct ProcessCommandInvoker: CommandInvoker {
         args.append("\(user)@\(host):\(remotePath)")
         // loose form:
         // scp -o StrictHostKeyChecking=no get-docker.sh "docker-user@${IP_ADDRESS}:get-docker.sh"
-        let rcAndPipe = try localShell(cmd: args)
+        let rcAndPipe = try await localShell(cmd: args)
         return rcAndPipe
     }
 
@@ -179,7 +179,7 @@ struct ProcessCommandInvoker: CommandInvoker {
         strictHostKeyChecking: Bool = false,
         cmd: [String],
         env: [String: String]? = nil
-    ) throws -> CommandOutput {
+    ) async throws -> CommandOutput {
         var args: [String] = ["ssh"]
         if strictHostKeyChecking {
             args.append("-o")
@@ -203,7 +203,7 @@ struct ProcessCommandInvoker: CommandInvoker {
         // does this with significantly more finness, checking the output as it's returned and providing a pass
         // to use sshpass to authenticate, or to escalate commands with sudo and a password, before the core
         // command is invoked.
-        let rcAndPipe = try localShell(cmd: args, env: env)
+        let rcAndPipe = try await localShell(cmd: args, env: env)
         return rcAndPipe
     }
 }

--- a/Sources/Formic/QueryableResource.swift
+++ b/Sources/Formic/QueryableResource.swift
@@ -36,7 +36,7 @@ public protocol Resource: Codable, Hashable, Sendable {
     /// Queries the state of the resource from the given host.
     /// - Parameter from: The host to inspect.
     /// - Returns: The state of the resource.
-    func queryResource(from: Host) throws -> (Self, Date)
+    func queryResource(from: Host) async throws -> (Self, Date)
 
 }
 
@@ -94,12 +94,12 @@ extension Resource {
     /// Queries the state of the resource from the given host.
     /// - Parameter host: The host to inspect.
     /// - Returns: The state of the resource and the time that it was last updated.
-    public func queryResource(from host: Host) throws -> (Self, Date) {
+    public func queryResource(from host: Host) async throws -> (Self, Date) {
         // default implementation:
 
         @Dependency(\.date.now) var date
         // run the command on the relevant host, capturing the output
-        let output: CommandOutput = try inquiry.run(host: host)
+        let output: CommandOutput = try await inquiry.run(host: host)
         // verify the return code is 0
         if output.returnCode != 0 {
             throw CommandError.commandFailed(rc: output.returnCode, errmsg: output.stderrString ?? "")
@@ -130,18 +130,18 @@ public protocol SingularResource: Resource {
     static var singularInquiry: Command { get }
     /// Returns a resource for the host you provide.
     /// - Parameter host: The host to inspect for the resource.
-    static func findResource(from host: Host) throws -> (Self, Date)
+    static func findResource(from host: Host) async throws -> (Self, Date)
 }
 
 extension SingularResource {
     /// Returns a resource for the host you provide.
     /// - Parameter host: The host to inspect for the resource.
-    public static func findResource(from host: Host) throws -> (Self, Date) {
+    public static func findResource(from host: Host) async throws -> (Self, Date) {
         // default implementation:
 
         @Dependency(\.date.now) var date
         // run the command on the relevant host, capturing the output
-        let output: CommandOutput = try singularInquiry.run(host: host)
+        let output: CommandOutput = try await singularInquiry.run(host: host)
         // verify the return code is 0
         if output.returnCode != 0 {
             throw CommandError.commandFailed(rc: output.returnCode, errmsg: output.stderrString ?? "")
@@ -166,7 +166,7 @@ public protocol NamedResource: Resource {
     /// Returns a resource for the host you provide.
     /// - Parameter name: The name of the resource to find.
     /// - Parameter host: The host to inspect for the resource.
-    static func findResource(_ name: String, from host: Host) throws -> (Self, Date)
+    static func findResource(_ name: String, from host: Host) async throws -> (Self, Date)
 }
 
 /// A collection of resources that can be found and queried from a host.
@@ -178,19 +178,19 @@ public protocol CollectionQueryableResource: Resource {
     static func collectionParse(_ output: String) throws -> [Self]
     /// Returns a list of resources for the host you provide.
     /// - Parameter from: The host to inspect.
-    static func queryResourceCollection(from: Host) throws -> ([Self], Date)
+    static func queryResourceCollection(from: Host) async throws -> ([Self], Date)
 }
 
 extension CollectionQueryableResource {
     /// Queries the state of the resource from the given host.
     /// - Parameter host: The host to inspect.
     /// - Returns: The state of the resource and the time that it was last updated.
-    public static func queryResourceCollection(from host: Host) throws -> ([Self], Date) {
+    public static func queryResourceCollection(from host: Host) async throws -> ([Self], Date) {
         // default implementation:
 
         @Dependency(\.date.now) var date
         // run the command on the relevant host, capturing the output
-        let output: CommandOutput = try collectionInquiry.run(host: host)
+        let output: CommandOutput = try await collectionInquiry.run(host: host)
         // verify the return code is 0
         if output.returnCode != 0 {
             throw CommandError.commandFailed(rc: output.returnCode, errmsg: output.stderrString ?? "")

--- a/Tests/formicTests/BackoffTests.swift
+++ b/Tests/formicTests/BackoffTests.swift
@@ -6,43 +6,43 @@ import Testing
 @Test("verify backoff logic - .none")
 func testBackoffDelayLogicNone() async throws {
     let strategy = Backoff.Strategy.none
-    #expect(strategy.delay(for: 0) == 0)
-    #expect(strategy.delay(for: 10) == 0)
+    #expect(strategy.delay(for: 0) == .seconds(0))
+    #expect(strategy.delay(for: 10) == .seconds(0))
 }
 
 @Test("verify backoff logic - .constant")
 func testBackoffDelayLogicConstant() async throws {
-    let strategy = Backoff.Strategy.constant(delay: 3.5)
-    #expect(strategy.delay(for: 0) == 3.5)
-    #expect(strategy.delay(for: 10) == 3.5)
+    let strategy = Backoff.Strategy.constant(delay: .seconds(3.5))
+    #expect(strategy.delay(for: 0) == .seconds(3.5))
+    #expect(strategy.delay(for: 10) == .seconds(3.5))
 }
 
 @Test("verify backoff logic - .linear")
 func testBackoffDelayLogicLinear() async throws {
-    let strategy = Backoff.Strategy.linear(increment: 2, maxDelay: 3.5)
-    #expect(strategy.delay(for: 0) == 0)
-    #expect(strategy.delay(for: 1) == 2)
-    #expect(strategy.delay(for: 10) == 3.5)
+    let strategy = Backoff.Strategy.linear(increment: .seconds(2), maxDelay: .seconds(3.5))
+    #expect(strategy.delay(for: 0) == .seconds(0))
+    #expect(strategy.delay(for: 1) == .seconds(2))
+    #expect(strategy.delay(for: 10) == .seconds(3.5))
 }
 
 @Test("verify backoff logic - .fibonacci")
 func testBackoffDelayLogicFibonacci() async throws {
-    let strategy = Backoff.Strategy.fibonacci(maxDelay: 3.5)
-    #expect(strategy.delay(for: 0) == 0)
-    #expect(strategy.delay(for: 1) == 1)
-    #expect(strategy.delay(for: 2) == 1)
-    #expect(strategy.delay(for: 3) == 2)
-    #expect(strategy.delay(for: 4) == 3)
-    #expect(strategy.delay(for: 10) == 3.5)
+    let strategy = Backoff.Strategy.fibonacci(maxDelay: .seconds(3.5))
+    #expect(strategy.delay(for: 0) == .seconds(0))
+    #expect(strategy.delay(for: 1) == .seconds(1))
+    #expect(strategy.delay(for: 2) == .seconds(1))
+    #expect(strategy.delay(for: 3) == .seconds(2))
+    #expect(strategy.delay(for: 4) == .seconds(3))
+    #expect(strategy.delay(for: 10) == .seconds(3.5))
 }
 
 @Test("verify backoff logic - .exponential")
 func testBackoffDelayLogicExponential() async throws {
-    let strategy = Backoff.Strategy.exponential(maxDelay: 3.5)
-    #expect(strategy.delay(for: 0) == 0)
-    #expect(strategy.delay(for: 1) == 1)
-    #expect(strategy.delay(for: 2) == 2)
-    #expect(strategy.delay(for: 3) == 3.5)
-    #expect(strategy.delay(for: 4) == 3.5)
-    #expect(strategy.delay(for: 10) == 3.5)
+    let strategy = Backoff.Strategy.exponential(maxDelay: .seconds(3.5))
+    #expect(strategy.delay(for: 0) == .seconds(0))
+    #expect(strategy.delay(for: 1) == .seconds(1))
+    #expect(strategy.delay(for: 2) == .seconds(2))
+    #expect(strategy.delay(for: 3) == .seconds(3.5))
+    #expect(strategy.delay(for: 4) == .seconds(3.5))
+    #expect(strategy.delay(for: 10) == .seconds(3.5))
 }

--- a/Tests/formicTests/CommandInvokerTests.swift
+++ b/Tests/formicTests/CommandInvokerTests.swift
@@ -9,7 +9,7 @@ import Testing
     .timeLimit(.minutes(1)),
     .tags(.functionalTest))
 func invokeBasicCommandLocally() async throws {
-    let shellResult = try ProcessCommandInvoker().localShell(cmd: ["uname"], stdIn: nil, env: nil)
+    let shellResult = try await ProcessCommandInvoker().localShell(cmd: ["uname"], stdIn: nil, env: nil)
 
     // results expected on a Linux host only
     #expect(shellResult.returnCode == 0)

--- a/Tests/formicTests/CommandTests.swift
+++ b/Tests/formicTests/CommandTests.swift
@@ -5,10 +5,9 @@ import Testing
 @Test("initializing a shell command")
 func shellCommandDeclarationTest() async throws {
     let command = Command.shell("uname")
-    #expect(command.retryOnFailure == false)
+    #expect(command.retry == .none)
     #expect(command.args == ["uname"])
     #expect(command.env == nil)
-    #expect(command.backoff == .default)
     #expect(command.id != nil)
 
     #expect(command.description == "uname")
@@ -24,23 +23,26 @@ func verifyIdentifiableCommands() async throws {
 @Test("initializing a shell command with all options")
 func shellCommandFullDeclarationTest() async throws {
     let command = Command.shell(
-        "ls", env: ["PATH": "/usr/bin"], retryOnFailure: true,
-        backoff: Backoff(maxRetries: 200, strategy: .exponential(maxDelay: 60)))
-    #expect(command.retryOnFailure == true)
+        "ls", env: ["PATH": "/usr/bin"],
+        retry: .retryOnFailure(
+            Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60)))))
     #expect(command.args == ["ls"])
     #expect(command.env == ["PATH": "/usr/bin"])
-    #expect(command.backoff == Backoff(maxRetries: 200, strategy: .exponential(maxDelay: 60)))
-
+    #expect(command.retry != .none)
+    guard case .retryOnFailure(let backoff) = command.retry else {
+        Issue.record("Unexpected type found in retry: \(command.retry)")
+        return
+    }
+    #expect(backoff == Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60))))
     #expect(command.description == "ls")
 }
 
 @Test("initializing a copy command")
 func copyCommandDeclarationTest() async throws {
     let command = Command.remoteCopy(from: "one", to: "two")
-    #expect(command.retryOnFailure == false)
+    #expect(command.retry == .none)
     #expect(command.args == ["one", "two"])
     #expect(command.env == nil)
-    #expect(command.backoff == .default)
 
     #expect(command.description == "scp one to remote host:two")
 }
@@ -48,12 +50,16 @@ func copyCommandDeclarationTest() async throws {
 @Test("initializing a copy command with all options")
 func copyCommandFullDeclarationTest() async throws {
     let command = Command.remoteCopy(
-        from: "one", to: "two", retryOnFailure: true,
-        backoff: Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: 60)))
-    #expect(command.retryOnFailure == true)
+        from: "one", to: "two",
+        retry: .retryOnFailure(Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60)))))
     #expect(command.args == ["one", "two"])
     #expect(command.env == nil)
-    #expect(command.backoff == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: 60)))
+    #expect(command.retry != .none)
+    guard case .retryOnFailure(let backoff) = command.retry else {
+        Issue.record("Unexpected type found in retry: \(command.retry)")
+        return
+    }
+    #expect(backoff == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
 
     #expect(command.description == "scp one to remote host:two")
 }

--- a/Tests/formicTests/Resources/OperatingSystem.swift
+++ b/Tests/formicTests/Resources/OperatingSystem.swift
@@ -53,10 +53,11 @@ func testOSStringInitializer() async throws {
 
 @Test("verify the OperatingSystem.singularInquiry(_:String) function")
 func testOperatingSystemSingularInquiry() async throws {
-    let shellResult: CommandOutput = try withDependencies {
-        $0.commandInvoker = TestCommandInvoker(command: ["uname"], presentOutput: "Linux\n")
+    let shellResult: CommandOutput = try await withDependencies {
+        $0.commandInvoker = TestCommandInvoker()
+            .addSuccess(command: ["uname"], presentOutput: "Linux\n")
     } operation: {
-        try OperatingSystem.singularInquiry.run(host: .localhost)
+        try await OperatingSystem.singularInquiry.run(host: .localhost)
     }
 
     // results proxied for a linux host
@@ -73,11 +74,13 @@ func testOperatingSystemParse() async throws {
 @Test("test singular findResource for operating system")
 func testOperatingSystemQuery() async throws {
 
-    let (parsedOS, _) = try withDependencies {
-        $0.commandInvoker = TestCommandInvoker(command: ["uname"], presentOutput: "Linux\n")
+    let (parsedOS, _) = try await withDependencies {
+        $0.commandInvoker = TestCommandInvoker()
+            .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+
         $0.date.now = Date(timeIntervalSince1970: 1_234_567_890)
     } operation: {
-        try OperatingSystem.findResource(from: .localhost)
+        try await OperatingSystem.findResource(from: .localhost)
     }
 
     #expect(parsedOS.name == .linux)
@@ -88,11 +91,12 @@ func testOperatingSystemInstanceQuery() async throws {
 
     let instance = OperatingSystem(.macOS)
 
-    let (parsedOS, _) = try withDependencies {
-        $0.commandInvoker = TestCommandInvoker(command: ["uname"], presentOutput: "Linux\n")
+    let (parsedOS, _) = try await withDependencies {
+        $0.commandInvoker = TestCommandInvoker()
+            .addSuccess(command: ["uname"], presentOutput: "Linux\n")
         $0.date.now = Date(timeIntervalSince1970: 1_234_567_890)
     } operation: {
-        try instance.queryResource(from: .localhost)
+        try await instance.queryResource(from: .localhost)
     }
 
     #expect(parsedOS.name == .linux)


### PR DESCRIPTION
Enable timeout on command

## Description
- adds Duration to command declaration for a max delay allowed, throws exception otherwise
- plumbs async down through invoker to enable testing

## Motivation and Context
resolves #30

## How has this been tested?
- added timeout to TestInvoker processing with Task.sleep
- added test to work `engine.run() async` to verify timeout throws exception properly

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

(changes public API from sync to async in Command to allow for testing, and it's generally more sensible)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] I have run `./scripts/preflight.bash` and it passed without errors.
