### PR TITLE
simplifying the whole backoff thing after I overcomplicated it

### DIFF
--- a/Sources/Formic/Backoff.swift
+++ b/Sources/Formic/Backoff.swift
@@ -61,10 +61,10 @@ public struct Backoff: Sendable, Hashable, Codable {
         self.strategy = strategy
     }
 
-    /// Default backoff settings
+    /// Never attempt retry
     ///
     /// Do not attempt to retry on failure.
-    public static var none: Backoff {
+    public static var never: Backoff {
         Backoff(maxRetries: 0, strategy: .constant(delay: .seconds(1)))
     }
 

--- a/Sources/Formic/Backoff.swift
+++ b/Sources/Formic/Backoff.swift
@@ -65,7 +65,7 @@ public struct Backoff: Sendable, Hashable, Codable {
     ///
     /// Do not attempt to retry on failure.
     public static var never: Backoff {
-        Backoff(maxRetries: 0, strategy: .constant(delay: .seconds(1)))
+        Backoff(maxRetries: 0, strategy: .none)
     }
 
     /// Default backoff settings

--- a/Sources/Formic/Command.swift
+++ b/Sources/Formic/Command.swift
@@ -4,7 +4,7 @@ import Foundation
 public protocol Command: Sendable, Identifiable, Hashable, Codable {
     var id: UUID { get }
     var ignoreFailure: Bool { get }
-    var retry: RetrySetting { get }
+    var retry: Backoff { get }
     var executionTimeout: Duration { get }
 
     func run(host: Host) async throws -> CommandOutput

--- a/Sources/Formic/Commands/CopyFrom.swift
+++ b/Sources/Formic/Commands/CopyFrom.swift
@@ -31,7 +31,7 @@ public struct CopyFrom: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         location: String, from: URL, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .never, executionTimeout: Duration = .seconds(30)
     ) {
         self.from = from
         self.env = env

--- a/Sources/Formic/Commands/CopyFrom.swift
+++ b/Sources/Formic/Commands/CopyFrom.swift
@@ -15,7 +15,7 @@ public struct CopyFrom: Command {
     /// A Boolean value that indicates whether a failing command should fail a playbook.
     public let ignoreFailure: Bool
     /// The retry settings for the command.
-    public let retry: RetrySetting
+    public let retry: Backoff
     /// The maximum duration to allow for the command.
     public let executionTimeout: Duration
     /// The ID of the command.
@@ -31,7 +31,7 @@ public struct CopyFrom: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         location: String, from: URL, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: RetrySetting = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
     ) {
         self.from = from
         self.env = env

--- a/Sources/Formic/Commands/CopyInto.swift
+++ b/Sources/Formic/Commands/CopyInto.swift
@@ -30,7 +30,7 @@ public struct CopyInto: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         location: String, from: String, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .never, executionTimeout: Duration = .seconds(30)
     ) {
         self.from = from
         self.env = env

--- a/Sources/Formic/Commands/CopyInto.swift
+++ b/Sources/Formic/Commands/CopyInto.swift
@@ -14,7 +14,7 @@ public struct CopyInto: Command {
     /// A Boolean value that indicates whether a failing command should fail a playbook.
     public let ignoreFailure: Bool
     /// The retry settings for the command.
-    public let retry: RetrySetting
+    public let retry: Backoff
     /// The maximum duration to allow for the command.
     public let executionTimeout: Duration
     /// The ID of the command.
@@ -30,7 +30,7 @@ public struct CopyInto: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         location: String, from: String, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: RetrySetting = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
     ) {
         self.from = from
         self.env = env

--- a/Sources/Formic/Commands/ShellCommand.swift
+++ b/Sources/Formic/Commands/ShellCommand.swift
@@ -27,7 +27,7 @@ public struct ShellCommand: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         arguments: [String], env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .never, executionTimeout: Duration = .seconds(30)
     ) {
         self.args = arguments
         self.env = env
@@ -49,7 +49,7 @@ public struct ShellCommand: Command {
     /// If a command, or argument, requires a whitespace within it, use ``init(arguments:env:ignoreFailure:retry:executionTimeout:)`` instead.
     public init(
         _ argString: String, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .never, executionTimeout: Duration = .seconds(30)
     ) {
         let splitArgs: [String] = argString.split(separator: .whitespace).map(String.init)
         self.init(
@@ -66,7 +66,7 @@ public struct ShellCommand: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         argumentStrings: String..., env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .never, executionTimeout: Duration = .seconds(30)
     ) {
         self.init(
             arguments: argumentStrings, env: env, ignoreFailure: ignoreFailure, retry: retry,

--- a/Sources/Formic/Commands/ShellCommand.swift
+++ b/Sources/Formic/Commands/ShellCommand.swift
@@ -12,7 +12,7 @@ public struct ShellCommand: Command {
     /// A Boolean value that indicates whether a failing command should fail a playbook.
     public let ignoreFailure: Bool
     /// The retry settings for the command.
-    public let retry: RetrySetting
+    public let retry: Backoff
     /// The maximum duration to allow for the command.
     public let executionTimeout: Duration
     /// The ID of the command.
@@ -27,7 +27,7 @@ public struct ShellCommand: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         arguments: [String], env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: RetrySetting = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
     ) {
         self.args = arguments
         self.env = env
@@ -49,7 +49,7 @@ public struct ShellCommand: Command {
     /// If a command, or argument, requires a whitespace within it, use ``init(arguments:env:ignoreFailure:retry:executionTimeout:)`` instead.
     public init(
         _ argString: String, env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: RetrySetting = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
     ) {
         let splitArgs: [String] = argString.split(separator: .whitespace).map(String.init)
         self.init(
@@ -66,7 +66,7 @@ public struct ShellCommand: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         argumentStrings: String..., env: [String: String]? = nil, ignoreFailure: Bool = false,
-        retry: RetrySetting = .none, executionTimeout: Duration = .seconds(30)
+        retry: Backoff = .none, executionTimeout: Duration = .seconds(30)
     ) {
         self.init(
             arguments: argumentStrings, env: env, ignoreFailure: ignoreFailure, retry: retry,

--- a/Sources/Formic/Commands/VerifyAccess.swift
+++ b/Sources/Formic/Commands/VerifyAccess.swift
@@ -6,7 +6,7 @@ public struct VerifyAccess: Command {
     /// A Boolean value that indicates whether a failing command should fail a playbook.
     public let ignoreFailure: Bool
     /// The retry settings for the command.
-    public let retry: RetrySetting
+    public let retry: Backoff
     /// The maximum duration to allow for the command.
     public let executionTimeout: Duration
     /// The ID of the command.
@@ -19,10 +19,9 @@ public struct VerifyAccess: Command {
     ///   - executionTimeout: The maximum duration to allow for the command.
     public init(
         ignoreFailure: Bool = false,
-        retry: RetrySetting = .retryOnFailure(
-            Backoff(
-                maxRetries: 10,
-                strategy: .fibonacci(maxDelay: .seconds(600)))),
+        retry: Backoff = Backoff(
+            maxRetries: 10,
+            strategy: .fibonacci(maxDelay: .seconds(600))),
         executionTimeout: Duration = .seconds(30)
     ) {
         self.retry = retry

--- a/Sources/Formic/Documentation.docc/Command.md
+++ b/Sources/Formic/Documentation.docc/Command.md
@@ -8,6 +8,7 @@
 - ``Command/ignoreFailure``
 - ``Command/retry``
 - ``Command/executionTimeout``
+- ``Backoff``
 
 ### Invoking Commands
 

--- a/Sources/Formic/Documentation.docc/Documentation.md
+++ b/Sources/Formic/Documentation.docc/Documentation.md
@@ -28,7 +28,6 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 
 - ``Host``
 - ``Command``
-- ``RetrySetting``
 - ``CommandOutput``
 - ``CommandError``
 

--- a/Sources/Formic/Documentation.docc/RetrySetting.md
+++ b/Sources/Formic/Documentation.docc/RetrySetting.md
@@ -1,9 +1,0 @@
-# ``RetrySetting``
-
-## Topics
-
-### Inspecting the setting
-
-- ``none``
-- ``retryOnFailure(_:)``
-- ``Backoff``

--- a/Tests/formicTests/BackoffTests.swift
+++ b/Tests/formicTests/BackoffTests.swift
@@ -10,6 +10,23 @@ func testBackoffDelayLogicNone() async throws {
     #expect(strategy.delay(for: 10) == .seconds(0))
 }
 
+@Test("verify backoff builtins")
+func testBackoffBuiltings() async throws {
+    let backoff = Backoff.never
+    #expect(backoff.maxRetries == 0)
+    #expect(backoff.strategy == .none)
+
+    let backoff2 = Backoff.default
+    #expect(backoff2.maxRetries == 3)
+    #expect(backoff2.strategy == .fibonacci(maxDelay: .seconds(10)))
+}
+
+@Test("verify backoff initializer with negative value")
+func testBackoffDelayInitnegative() async throws {
+    let negBackoff = Backoff(maxRetries: -1, strategy: .none)
+    #expect(negBackoff.maxRetries == 0)
+}
+
 @Test("verify backoff logic - .constant")
 func testBackoffDelayLogicConstant() async throws {
     let strategy = Backoff.Strategy.constant(delay: .seconds(3.5))

--- a/Tests/formicTests/Commands/CopyFromTests.swift
+++ b/Tests/formicTests/Commands/CopyFromTests.swift
@@ -9,7 +9,7 @@ func copyFromCommandDeclarationTest() async throws {
 
     let url: URL = try #require(URL(string: "http://somehost.com/datafile"))
     let command = CopyFrom(location: "/dest/path", from: url)
-    #expect(command.retry == .none)
+    #expect(command.retry == .never)
     #expect(command.from == url)
     #expect(command.destinationPath == "/dest/path")
     #expect(command.env == nil)

--- a/Tests/formicTests/Commands/CopyFromTests.swift
+++ b/Tests/formicTests/Commands/CopyFromTests.swift
@@ -22,16 +22,11 @@ func copyFromCommandFullDeclarationTest() async throws {
     let url: URL = try #require(URL(string: "http://somehost.com/datafile"))
     let command = CopyFrom(
         location: "/dest/path", from: url,
-        retry: .retryOnFailure(Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60)))))
+        retry: Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
     #expect(command.from == url)
     #expect(command.destinationPath == "/dest/path")
     #expect(command.env == nil)
-    #expect(command.retry != .none)
-    guard case .retryOnFailure(let backoff) = command.retry else {
-        Issue.record("Unexpected type found in retry: \(command.retry)")
-        return
-    }
-    #expect(backoff == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
+    #expect(command.retry == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
 
     #expect(command.description == "scp http://somehost.com/datafile to remote host:/dest/path")
 }

--- a/Tests/formicTests/Commands/CopyIntoTests.swift
+++ b/Tests/formicTests/Commands/CopyIntoTests.swift
@@ -19,16 +19,11 @@ func copyCommandDeclarationTest() async throws {
 func copyCommandFullDeclarationTest() async throws {
     let command = CopyInto(
         location: "two", from: "one",
-        retry: .retryOnFailure(Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60)))))
+        retry: Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
     #expect(command.from == "one")
     #expect(command.destinationPath == "two")
     #expect(command.env == nil)
-    #expect(command.retry != .none)
-    guard case .retryOnFailure(let backoff) = command.retry else {
-        Issue.record("Unexpected type found in retry: \(command.retry)")
-        return
-    }
-    #expect(backoff == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
+    #expect(command.retry == Backoff(maxRetries: 100, strategy: .fibonacci(maxDelay: .seconds(60))))
 
     #expect(command.description == "scp one to remote host:two")
 }

--- a/Tests/formicTests/Commands/CopyIntoTests.swift
+++ b/Tests/formicTests/Commands/CopyIntoTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Test("initializing a copy command")
 func copyCommandDeclarationTest() async throws {
     let command = CopyInto(location: "two", from: "one")
-    #expect(command.retry == .none)
+    #expect(command.retry == .never)
     #expect(command.from == "one")
     #expect(command.destinationPath == "two")
     #expect(command.env == nil)

--- a/Tests/formicTests/Commands/ShellCommandTests.swift
+++ b/Tests/formicTests/Commands/ShellCommandTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Test("initializing a shell command")
 func shellCommandDeclarationTest() async throws {
     let command = ShellCommand("uname")
-    #expect(command.retry == .none)
+    #expect(command.retry == .never)
     #expect(command.args == ["uname"])
     #expect(command.env == nil)
     #expect(command.id != nil)

--- a/Tests/formicTests/Commands/ShellCommandTests.swift
+++ b/Tests/formicTests/Commands/ShellCommandTests.swift
@@ -26,16 +26,10 @@ func verifyIdentifiableCommands() async throws {
 func shellCommandFullDeclarationTest() async throws {
     let command = ShellCommand(
         "ls", env: ["PATH": "/usr/bin"],
-        retry: .retryOnFailure(
-            Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60)))))
+        retry: Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60))))
     #expect(command.args == ["ls"])
     #expect(command.env == ["PATH": "/usr/bin"])
-    #expect(command.retry != .none)
-    guard case .retryOnFailure(let backoff) = command.retry else {
-        Issue.record("Unexpected type found in retry: \(command.retry)")
-        return
-    }
-    #expect(backoff == Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60))))
+    #expect(command.retry == Backoff(maxRetries: 200, strategy: .exponential(maxDelay: .seconds(60))))
     #expect(command.description == "ls")
 }
 

--- a/Tests/formicTests/EngineTests.swift
+++ b/Tests/formicTests/EngineTests.swift
@@ -643,7 +643,7 @@ func testCommandTimeout() async throws {
 func testCommandRetry() async throws {
     typealias Host = Formic.Host
     let engine = Engine()
-    let cmd1 = ShellCommand("uname", retry: .retryOnFailure(.default))
+    let cmd1 = ShellCommand("uname", retry: .default)
 
     let fakeHost = try await withDependencies { dependencyValues in
         dependencyValues.localSystemAccess = TestFileSystemAccess(


### PR DESCRIPTION
## Description
Simplify how commands define, and use, a retry strategy and settings

## Motivation and Context
Upper level case enum thing was atrocious, and unneeded. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
