### PR TITLE
Addijitter

### DIFF
--- a/Sources/Formic/Backoff.swift
+++ b/Sources/Formic/Backoff.swift
@@ -45,7 +45,7 @@ public struct Backoff: Sendable, Hashable, Codable {
             case .fibonacci(let maxDelay):
                 if attempt >= Self.fibBackoffs.count {
                     if withJitter {
-                        return Self.jitterValue(base: .seconds(610), max: maxDelay)
+                        return Self.jitterValue(base: min(.seconds(610), maxDelay), max: maxDelay)
                     } else {
                         return min(.seconds(610), maxDelay)
                     }
@@ -58,7 +58,7 @@ public struct Backoff: Sendable, Hashable, Codable {
             case .exponential(let maxDelay):
                 if attempt >= Self.exponentialBackoffs.count {
                     if withJitter {
-                        return Self.jitterValue(base: .seconds(512), max: maxDelay)
+                        return Self.jitterValue(base: min(.seconds(512), maxDelay), max: maxDelay)
                     } else {
                         return min(.seconds(512), maxDelay)
                     }

--- a/Sources/Formic/Engine/Engine.swift
+++ b/Sources/Formic/Engine/Engine.swift
@@ -372,7 +372,7 @@ public actor Engine {
                     duration: durationOfLastAttempt, retries: numberOfRetries,
                     exception: nil)
             } else {
-                let delay = command.retry.strategy.delay(for: numberOfRetries)
+                let delay = command.retry.strategy.delay(for: numberOfRetries, withJitter: true)
                 try await Task.sleep(for: delay)
             }
         } while command.retry.retryOnFailure && numberOfRetries < command.retry.maxRetries

--- a/Tests/formicTests/BackoffTests.swift
+++ b/Tests/formicTests/BackoffTests.swift
@@ -6,8 +6,8 @@ import Testing
 @Test("verify backoff logic - .none")
 func testBackoffDelayLogicNone() async throws {
     let strategy = Backoff.Strategy.none
-    #expect(strategy.delay(for: 0) == .seconds(0))
-    #expect(strategy.delay(for: 10) == .seconds(0))
+    #expect(strategy.delay(for: 0, withJitter: false) == .seconds(0))
+    #expect(strategy.delay(for: 10, withJitter: false) == .seconds(0))
 }
 
 @Test("verify backoff builtins")
@@ -30,36 +30,59 @@ func testBackoffDelayInitnegative() async throws {
 @Test("verify backoff logic - .constant")
 func testBackoffDelayLogicConstant() async throws {
     let strategy = Backoff.Strategy.constant(delay: .seconds(3.5))
-    #expect(strategy.delay(for: 0) == .seconds(3.5))
-    #expect(strategy.delay(for: 10) == .seconds(3.5))
+    #expect(strategy.delay(for: 0, withJitter: false) == .seconds(3.5))
+    #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
 }
 
 @Test("verify backoff logic - .linear")
 func testBackoffDelayLogicLinear() async throws {
     let strategy = Backoff.Strategy.linear(increment: .seconds(2), maxDelay: .seconds(3.5))
-    #expect(strategy.delay(for: 0) == .seconds(0))
-    #expect(strategy.delay(for: 1) == .seconds(2))
-    #expect(strategy.delay(for: 10) == .seconds(3.5))
+    #expect(strategy.delay(for: 0, withJitter: false) == .seconds(0))
+    #expect(strategy.delay(for: 1, withJitter: false) == .seconds(2))
+    #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
+
+    #expect(strategy.delay(for: 1, withJitter: true) != .seconds(2))
 }
 
 @Test("verify backoff logic - .fibonacci")
 func testBackoffDelayLogicFibonacci() async throws {
     let strategy = Backoff.Strategy.fibonacci(maxDelay: .seconds(3.5))
-    #expect(strategy.delay(for: 0) == .seconds(0))
-    #expect(strategy.delay(for: 1) == .seconds(1))
-    #expect(strategy.delay(for: 2) == .seconds(1))
-    #expect(strategy.delay(for: 3) == .seconds(2))
-    #expect(strategy.delay(for: 4) == .seconds(3))
-    #expect(strategy.delay(for: 10) == .seconds(3.5))
+    #expect(strategy.delay(for: 0, withJitter: false) == .seconds(0))
+    #expect(strategy.delay(for: 1, withJitter: false) == .seconds(1))
+    #expect(strategy.delay(for: 2, withJitter: false) == .seconds(1))
+    #expect(strategy.delay(for: 3, withJitter: false) == .seconds(2))
+    #expect(strategy.delay(for: 4, withJitter: false) == .seconds(3))
+    #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
+
+    #expect(strategy.delay(for: 3, withJitter: true) != .seconds(2))
 }
 
 @Test("verify backoff logic - .exponential")
 func testBackoffDelayLogicExponential() async throws {
     let strategy = Backoff.Strategy.exponential(maxDelay: .seconds(3.5))
-    #expect(strategy.delay(for: 0) == .seconds(0))
-    #expect(strategy.delay(for: 1) == .seconds(1))
-    #expect(strategy.delay(for: 2) == .seconds(2))
-    #expect(strategy.delay(for: 3) == .seconds(3.5))
-    #expect(strategy.delay(for: 4) == .seconds(3.5))
-    #expect(strategy.delay(for: 10) == .seconds(3.5))
+    #expect(strategy.delay(for: 0, withJitter: false) == .seconds(0))
+    #expect(strategy.delay(for: 1, withJitter: false) == .seconds(1))
+    #expect(strategy.delay(for: 2, withJitter: false) == .seconds(2))
+    #expect(strategy.delay(for: 3, withJitter: false) == .seconds(3.5))
+    #expect(strategy.delay(for: 4, withJitter: false) == .seconds(3.5))
+    #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
+
+    #expect(strategy.delay(for: 2, withJitter: true) != .seconds(2))
+}
+
+@Test("verify jitter logic")
+func testBackoffDelayJitter() async throws {
+    for _ in 0..<100 {
+        let jitterValue = Backoff.Strategy.jitterValue(base: .seconds(2), max: .seconds(2))
+        // plus or minus 5 % of the base value = +/- 0.1 seconds, but never above max
+        #expect(jitterValue >= .seconds(1.9))
+        #expect(jitterValue <= .seconds(2.0))
+    }
+
+    for _ in 0..<100 {
+        let jitterValue = Backoff.Strategy.jitterValue(base: .seconds(2), max: .seconds(3))
+        // plus or minus 5 % of the base value = +/- 0.1 seconds, but never above max
+        #expect(jitterValue >= .seconds(1.9))
+        #expect(jitterValue <= .seconds(2.1))
+    }
 }

--- a/Tests/formicTests/BackoffTests.swift
+++ b/Tests/formicTests/BackoffTests.swift
@@ -55,6 +55,7 @@ func testBackoffDelayLogicFibonacci() async throws {
     #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
 
     #expect(strategy.delay(for: 3, withJitter: true) != .seconds(2))
+    #expect(strategy.delay(for: 20, withJitter: true) <= .seconds(3.5))
 }
 
 @Test("verify backoff logic - .exponential")
@@ -68,6 +69,7 @@ func testBackoffDelayLogicExponential() async throws {
     #expect(strategy.delay(for: 10, withJitter: false) == .seconds(3.5))
 
     #expect(strategy.delay(for: 2, withJitter: true) != .seconds(2))
+    #expect(strategy.delay(for: 20, withJitter: true) <= .seconds(3.5))
 }
 
 @Test("verify jitter logic")


### PR DESCRIPTION


## Description
Adds a jitter value to the delay in a retry backoff so that there isn't a possibility of hammering concurrently. +/- 5% of base value, never below 0, never above max.

## Motivation and Context
resolves #50 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
