### PR TITLE
extends CommandOutput with some useful static constructors

### DIFF
--- a/Sources/Formic/CommandOutput.swift
+++ b/Sources/Formic/CommandOutput.swift
@@ -40,6 +40,18 @@ public struct CommandOutput: Sendable {
     public static var empty: CommandOutput {
         CommandOutput(returnCode: 0, stdOut: nil, stdErr: nil)
     }
+
+    /// Creates a command out that represents a success.
+    /// - Parameter msg: A message to include as the standard output.
+    public static func generalSuccess(msg: String) -> CommandOutput {
+        CommandOutput(returnCode: 0, stdOut: msg.data(using: .utf8), stdErr: nil)
+    }
+
+    /// Creates a command out that represents a failure.
+    /// - Parameter msg: A message to include as the standard error.
+    public static func generalFailure(msg: String) -> CommandOutput {
+        CommandOutput(returnCode: -1, stdOut: nil, stdErr: msg.data(using: .utf8))
+    }
 }
 
 extension CommandOutput: Hashable {}

--- a/Sources/Formic/Documentation.docc/CommandOutput.md
+++ b/Sources/Formic/Documentation.docc/CommandOutput.md
@@ -5,6 +5,8 @@
 ### Creating output
 
 - ``empty``
+- ``generalSuccess(msg:)``
+- ``generalFailure(msg:)``
 
 ### Inspecting Command Output
 

--- a/Tests/formicTests/CommandOutputTests.swift
+++ b/Tests/formicTests/CommandOutputTests.swift
@@ -13,3 +13,19 @@ func initCommandOutput() async throws {
     #expect(output.stdoutString == "Darwin\n")
     #expect(output.stderrString == nil)
 }
+
+@Test("CommandOutput builtins")
+func testCommandOutputBuiltins() async throws {
+    #expect(CommandOutput.empty.returnCode == 0)
+    #expect(CommandOutput.empty.stdoutString == nil)
+    #expect(CommandOutput.empty.stderrString == nil)
+
+    #expect(CommandOutput.generalFailure(msg: "A").returnCode == -1)
+    #expect(CommandOutput.generalFailure(msg: "A").stdoutString == nil)
+    #expect(CommandOutput.generalFailure(msg: "A").stderrString == "A")
+
+    #expect(CommandOutput.generalSuccess(msg: "A").returnCode == 0)
+    #expect(CommandOutput.generalSuccess(msg: "A").stdoutString == "A")
+    #expect(CommandOutput.generalSuccess(msg: "A").stderrString == nil)
+
+}


### PR DESCRIPTION
extends CommandOutput with some useful static constructors


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
