### PR TITLE
enabling a general command

### DIFF
--- a/Sources/Formic/Command.swift
+++ b/Sources/Formic/Command.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that represents a command, run locally or remotely.
-public protocol Command: Sendable, Identifiable, Hashable, Codable {
+public protocol Command: Sendable, Identifiable, Hashable {
     var id: UUID { get }
     var ignoreFailure: Bool { get }
     var retry: Backoff { get }

--- a/Sources/Formic/Commands/AnyCommand.swift
+++ b/Sources/Formic/Commands/AnyCommand.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A general command that is run against a host.
+public struct AnyCommand: Command {
+    /// A Boolean value that indicates whether a failing command should fail a playbook.
+    public let ignoreFailure: Bool
+    /// The retry settings for the command.
+    public let retry: Backoff
+    /// The maximum duration to allow for the command.
+    public let executionTimeout: Duration
+    /// The ID of the command.
+    public let id: UUID
+    let name: String
+    let commandClosure: @Sendable (Host) async throws -> CommandOutput
+
+    /// Invokes a command on the host to verify access.
+    /// - Parameters:
+    ///   - name: A name for this command.
+    ///   - ignoreFailure: A Boolean value that indicates whether a failing command should fail a playbook.
+    ///   - retry: The retry settings for the command.
+    ///   - executionTimeout: The maximum duration to allow for the command.
+    ///   - commandClosure: An asynchronous closure that the engine invokes when it runs the command.
+    public init(
+        name: String,
+        ignoreFailure: Bool,
+        retry: Backoff,
+        executionTimeout: Duration,
+        commandClosure: @escaping @Sendable (Host) async throws -> CommandOutput
+    ) {
+        self.retry = retry
+        self.ignoreFailure = ignoreFailure
+        self.executionTimeout = executionTimeout
+        self.commandClosure = commandClosure
+        self.name = name
+        id = UUID()
+    }
+
+    /// Runs the command to verify access to the host you provide.
+    /// - Parameter host: The host on which to run the command.
+    /// - Returns: The command output.
+    @discardableResult
+    public func run(host: Host) async throws -> CommandOutput {
+        try await commandClosure(host)
+    }
+}
+
+extension AnyCommand: Equatable {
+    /// Returns a Boolean value that indicates whether the two commands are equal.
+    /// - Parameters:
+    ///   - lhs: The first command.
+    ///   - rhs: The second command.
+    /// - Returns: `true` if the settings, name, and ID of the commands are equal; `false` otherwise.
+    public static func == (lhs: AnyCommand, rhs: AnyCommand) -> Bool {
+        lhs.id == rhs.id && lhs.ignoreFailure == rhs.ignoreFailure && lhs.retry == rhs.retry
+            && lhs.executionTimeout == rhs.executionTimeout && lhs.name == rhs.name
+    }
+}
+
+extension AnyCommand: Hashable {
+    /// Combines elements of the command to generate a hash value.
+    /// - Parameter hasher: The hasher to use when combining the components of the command.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(ignoreFailure)
+        hasher.combine(retry)
+        hasher.combine(executionTimeout)
+        hasher.combine(name)
+    }
+}
+
+extension AnyCommand: CustomStringConvertible {
+    /// A textual representation of the command.
+    public var description: String {
+        return name
+    }
+}

--- a/Sources/Formic/Documentation.docc/Documentation.md
+++ b/Sources/Formic/Documentation.docc/Documentation.md
@@ -36,6 +36,7 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 - ``ShellCommand``
 - ``CopyFrom``
 - ``CopyInto``
+- ``AnyCommand``
 
 ### Resources
 

--- a/Sources/Formic/QueryableResource.swift
+++ b/Sources/Formic/QueryableResource.swift
@@ -4,7 +4,7 @@ import Foundation
 // Resource pieces and operating on them:
 
 /// A type of resource that can be updated from a remote and supports collections and persistence.
-public protocol Resource: Codable, Hashable, Sendable {
+public protocol Resource: Hashable, Sendable {
     // IMPLEMENTATION NOTE:
     // Requirement 0 - persist-able and comparable
     //    - `Codable`, `Hashable`
@@ -119,7 +119,7 @@ extension Resource {
 
 /// A type of resource that exposes a declarative state.
 public protocol StatefulResource<DeclarativeStateType>: Resource {
-    associatedtype DeclarativeStateType: CustomStringConvertible, Sendable, Hashable, Codable
+    associatedtype DeclarativeStateType: CustomStringConvertible, Sendable, Hashable
     /// The state of this resource.
     var state: DeclarativeStateType { get }
 }

--- a/Tests/formicTests/Commands/AnyCommandTests.swift
+++ b/Tests/formicTests/Commands/AnyCommandTests.swift
@@ -1,0 +1,18 @@
+import Formic
+import Foundation
+import Testing
+
+@Test("initializing a generic AnyCommand")
+func anyCommandInit() async throws {
+    let command = AnyCommand(name: "myName", ignoreFailure: false, retry: .never, executionTimeout: .seconds(60)) { _ in
+        return CommandOutput.generalSuccess(msg: "done")
+    }
+
+    #expect(command.ignoreFailure == false)
+    #expect(command.retry == .never)
+    #expect(command.description == "myName")
+
+    let output = try await command.run(host: .localhost)
+    #expect(output.returnCode == 0)
+    #expect(output.stdoutString == "done")
+}

--- a/Tests/formicTests/Commands/AnyCommandTests.swift
+++ b/Tests/formicTests/Commands/AnyCommandTests.swift
@@ -16,3 +16,27 @@ func anyCommandInit() async throws {
     #expect(output.returnCode == 0)
     #expect(output.stdoutString == "done")
 }
+
+@Test("hashable AnyCommand")
+func anyCommandHashEquatable() async throws {
+    let command1 = AnyCommand(name: "myName", ignoreFailure: false, retry: .never, executionTimeout: .seconds(60)) {
+        _ in
+        return CommandOutput.generalSuccess(msg: "done")
+    }
+
+    let command2 = AnyCommand(name: "myName", ignoreFailure: true, retry: .default, executionTimeout: .seconds(60)) {
+        _ in
+        return CommandOutput.generalSuccess(msg: "done")
+    }
+
+    let command3 = AnyCommand(name: "myName", ignoreFailure: true, retry: .default, executionTimeout: .seconds(60)) {
+        _ in
+        return CommandOutput.generalSuccess(msg: "yep")
+    }
+
+    #expect(command1 != command2)
+    #expect(command1.hashValue != command2.hashValue)
+
+    // only because "ID" inside is different
+    #expect(command2.hashValue != command3.hashValue)
+}


### PR DESCRIPTION
enabling a general command

## Description
Provides a generic `Any`-style command where you can provide a sendable async closure to run.

## Motivation and Context
- drops the Codable requirements I'd shoved in there earlier to make this more flexible to the Swift author over a nailed-down external representation.

## Checklist
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] I have run `./scripts/preflight.bash` and it passed without errors.
