### PR TITLE
Reflection

### DIFF
--- a/Sources/Formic/Engine/Engine.swift
+++ b/Sources/Formic/Engine/Engine.swift
@@ -3,10 +3,10 @@ import Foundation
 /// An engine that runs playbooks and exposes the results.
 public actor Engine {
     let clock: ContinuousClock
-    var playbooks: [Playbook.ID: Playbook]
-    var states: [Playbook.ID: PlaybookState]
-    var commandResults: [Host: [UUID: CommandExecutionResult]]
-    var runners: [Host: Task<Void, any Error>]
+    //    var playbooks: [Playbook.ID: Playbook]
+    //    var states: [Playbook.ID: PlaybookState]
+    //    var commandResults: [Host: [UUID: CommandExecutionResult]]
+    //    var runners: [Host: Task<Void, any Error>]
 
     /// An asynchronous stream of state updates for playbooks.
     ///
@@ -23,10 +23,10 @@ public actor Engine {
     /// Creates a new engine.
     public init() {
         clock = ContinuousClock()
-        states = [:]
-        commandResults = [:]
-        runners = [:]
-        playbooks = [:]
+        //        states = [:]
+        //        commandResults = [:]
+        //        runners = [:]
+        //        playbooks = [:]
 
         // assemble the streams and continuations
         (playbookUpdates, stateContinuation) = AsyncStream.makeStream(of: (Playbook.ID, PlaybookState).self)
@@ -34,236 +34,236 @@ public actor Engine {
     }
 
     // MARK: Operating mode and scheduling
-
-    /// Run a playbook.
-    /// - Parameter playbook: The playbook to run.
-    /// - Parameter delay: The delay between steps.
-    /// - Parameter startRunner: A Boolean value that indicates whether to start the runner.
-    ///
-    /// If you schedule a playbook with `startRunner` set to `false`, the engine does not automatically
-    /// create a runner to process the commands.
-    /// Call ``step(for:)`` to process the commands individually.
-    public func schedule(_ playbook: Playbook, delay: Duration = .seconds(1), startRunner: Bool = true) {
-        for host in playbook.hosts {
-            if commandResults[host] == nil {
-                commandResults[host] = [:]
-            }
-        }
-        // store a copy of the playbook
-        playbooks[playbook.id] = playbook
-        // set the initial state of the playbook
-        states[playbook.id] = .scheduled
-        stateContinuation.yield((playbook.id, .scheduled))
-
-        for host in playbook.hosts {
-            // initialize empty result set for each host listed in the playbook, if needed
-            if commandResults[host] == nil {
-                commandResults[host] = [:]
-            }
-            // start a runner for each host listed in the playbook
-            if startRunner {
-                createHostRunnerIfNeeded(host: host, delay: delay)
-            }
-        }
-    }
-
-    internal func createHostRunnerIfNeeded(host: Host, delay: Duration) {
-        if runners[host] == nil {
-            //let runner = HostRunner(host: host, operatingMode: .ongoing, engine: self)
-            runners[host] = Task {
-                while !Task.isCancelled {
-                    await step(for: host)
-                    try await Task.sleep(for: delay)
-                }
-                self.runners[host] = nil
-            }
-        }
-    }
-
-    /// Cancels ongoing processing for the host you provide.
-    ///- Parameter playbookId: the Id of the playbook to cancel.
-    public func cancel(_ playbookId: Playbook.ID) {
-        if let state = states[playbookId] {
-            switch state {
-            case .scheduled, .running:
-                states[playbookId] = .cancelled
-                stateContinuation.yield((playbookId, .cancelled))
-            case .complete, .failed, .cancelled:
-                break
-            }
-        }
-    }
-
-    /// Cancels ongoing processing for the host you provide.
-    /// - Parameter host: The host to cancel processing for.
-    public func cancelRunner(for host: Host) {
-        if let runner = runners[host] {
-            runner.cancel()
-        }
-        runners[host] = nil
-    }
-
-    /// Returns a Boolean value that indicates whether there is active processing for the host you provide.
-    /// - Parameter host: The host to check.
-    public func runnerOperating(for host: Host) -> Bool {
-        return runners[host] != nil
-    }
-
-    /// Returns the current state of the playbook you provide.
-    /// - Parameter playbookId: The ID of the playbook to check.
-    /// - Returns: The current state of the execution of the playbook.
-    public func status(_ playbookId: Playbook.ID) -> PlaybookStatus? {
-        guard let playbook = playbooks[playbookId],
-            let state = states[playbookId]
-        else {
-            return nil
-        }
-        var hostResults: [Host: [UUID: CommandExecutionResult]] = [:]
-        // get a list of all the command IDs for this host in this playbook
-        // public let results: [Host:[Command.ID:CommandExecutionResult]]
-
-        for host in playbook.hosts {
-            var resultsForHost: [UUID: CommandExecutionResult] = [:]
-            // ALL results from the engine for this host
-            if let allEngineResults: [UUID: CommandExecutionResult] = commandResults[host] {
-                // only include the results for commands from this playbook
-                for commandId in playbook.commands.map(\.id) {
-                    if let executionResult = allEngineResults[commandId] {
-                        resultsForHost[commandId] = executionResult
-                    }
-                }
-            }
-            hostResults[host] = resultsForHost
-        }
-        return PlaybookStatus(state: state, playbook: playbook, results: hostResults)
-    }
-
-    // MARK: Coordination API
-
-    func availableCommandsForHost(host: Host) -> [(any Command, Playbook.ID)] {
-        var availableCommands: [(any Command, Playbook.ID)] = []
-        // list of playbooks that are either scheduled or running
-        // but not terminated, failed, or cancelled.
-        let availablePlaybookIds: [Playbook.ID] = playbooks.keys.filter { id in
-            // return true for isIncluded
-            guard let playbookStatus = states[id] else {
-                return false
-            }
-            if playbookStatus == .scheduled || playbookStatus == .running {
-                return true
-            }
-            return false
-        }
-        for playbookId in availablePlaybookIds {
-            guard let playbook = playbooks[playbookId] else {
-                continue
-            }
-            let completedCommandIDs: [UUID] = commandResults[host]?.keys.map { $0 } ?? []
-            let remainingCommands: [(any Command)] = playbook.commands.filter { command in
-                return !completedCommandIDs.contains(command.id)
-            }
-            for command in remainingCommands {
-                availableCommands.append((command, playbookId))
-            }
-        }
-        return availableCommands
-    }
-
-    func acceptResult(host: Host, result: CommandExecutionResult) {
-        // store the result
-        if var hostResultDict: [UUID: CommandExecutionResult] = commandResults[host] {
-            assert(hostResultDict[result.command.id] == nil, "Duplicate command result")
-            hostResultDict[result.command.id] = result
-            commandResults[host] = hostResultDict
-        } else {
-            // dictionary doesn't exist, create it and add result
-            commandResults[host] = [result.command.id: result]
-        }
-        // If the result has a playbook associated with it, update the playbook state
-        if let playbookId = result.playbookId {
-            // advance the state to running if it wasn't before
-            if states[playbookId] == .scheduled {
-                states[playbookId] = .running
-                stateContinuation.yield((playbookId, .running))
-            }
-            // if the result is failure, terminate the playbook unless its marked to be ignored
-            if result.output.returnCode != 0 && !result.command.ignoreFailure {
-                states[playbookId] = .failed
-                stateContinuation.yield((playbookId, .failed))
-            } else {
-                if result.command.id == playbooks[playbookId]?.commands.last?.id {
-                    // check for completion
-                    if playbookComplete(playbookId: playbookId) {
-                        states[playbookId] = .complete
-                        stateContinuation.yield((playbookId, .complete))
-                    }
-                }
-            }
-        }
-        // stream the result as well
-        commandContinuation.yield(result)
-    }
-
-    func playbookComplete(playbookId: Playbook.ID) -> Bool {
-        guard let originalPlaybook = playbooks[playbookId] else {
-            return false
-        }
-        for host in originalPlaybook.hosts {
-            guard let commandResultsForHost = commandResults[host],
-                commandResultsForHost.count == originalPlaybook.commands.count
-            else {
-                return false
-            }
-            // host has all commands reported from original playbook
-            let anyFailure = commandResultsForHost.contains { (id: UUID, result: CommandExecutionResult) in
-                result.output.returnCode != 0 && !result.command.ignoreFailure
-            }
-            if anyFailure {
-                return false
-            }
-        }
-        return true
-    }
-
-    func handleCommandException(
-        playbookId: Playbook.ID, host: Host, command: (any Command), exception: any Error
-    ) {
-        // store the result
-        let exceptionReport = CommandExecutionResult(
-            command: command, host: host, playbookId: playbookId, output: .empty, duration: .nanoseconds(0), retries: 0,
-            exception: exception.localizedDescription)
-        if var hostResultDict: [UUID: CommandExecutionResult] = commandResults[host] {
-            assert(hostResultDict[command.id] == nil, "Duplicate command result")
-            hostResultDict[command.id] = exceptionReport
-            commandResults[host] = hostResultDict
-        } else {
-            // dictionary doesn't exist, create it and add result
-            commandResults[host] = [command.id: exceptionReport]
-        }
-        states[playbookId] = .failed
-        stateContinuation.yield((playbookId, .failed))
-        // stream the result as well
-        commandContinuation.yield(exceptionReport)
-    }
+    //
+    //    /// Run a playbook.
+    //    /// - Parameter playbook: The playbook to run.
+    //    /// - Parameter delay: The delay between steps.
+    //    /// - Parameter startRunner: A Boolean value that indicates whether to start the runner.
+    //    ///
+    //    /// If you schedule a playbook with `startRunner` set to `false`, the engine does not automatically
+    //    /// create a runner to process the commands.
+    //    /// Call ``step(for:)`` to process the commands individually.
+    //    public func schedule(_ playbook: Playbook, delay: Duration = .seconds(1), startRunner: Bool = true) {
+    //        for host in playbook.hosts {
+    //            if commandResults[host] == nil {
+    //                commandResults[host] = [:]
+    //            }
+    //        }
+    //        // store a copy of the playbook
+    //        playbooks[playbook.id] = playbook
+    //        // set the initial state of the playbook
+    //        states[playbook.id] = .scheduled
+    //        stateContinuation.yield((playbook.id, .scheduled))
+    //
+    //        for host in playbook.hosts {
+    //            // initialize empty result set for each host listed in the playbook, if needed
+    //            if commandResults[host] == nil {
+    //                commandResults[host] = [:]
+    //            }
+    //            // start a runner for each host listed in the playbook
+    //            if startRunner {
+    //                createHostRunnerIfNeeded(host: host, delay: delay)
+    //            }
+    //        }
+    //    }
+    //
+    //    internal func createHostRunnerIfNeeded(host: Host, delay: Duration) {
+    //        if runners[host] == nil {
+    //            //let runner = HostRunner(host: host, operatingMode: .ongoing, engine: self)
+    //            runners[host] = Task {
+    //                while !Task.isCancelled {
+    //                    await step(for: host)
+    //                    try await Task.sleep(for: delay)
+    //                }
+    //                self.runners[host] = nil
+    //            }
+    //        }
+    //    }
+    //
+    //    /// Cancels ongoing processing for the host you provide.
+    //    ///- Parameter playbookId: the Id of the playbook to cancel.
+    //    public func cancel(_ playbookId: Playbook.ID) {
+    //        if let state = states[playbookId] {
+    //            switch state {
+    //            case .scheduled, .running:
+    //                states[playbookId] = .cancelled
+    //                stateContinuation.yield((playbookId, .cancelled))
+    //            case .complete, .failed, .cancelled:
+    //                break
+    //            }
+    //        }
+    //    }
+    //
+    //    /// Cancels ongoing processing for the host you provide.
+    //    /// - Parameter host: The host to cancel processing for.
+    //    public func cancelRunner(for host: Host) {
+    //        if let runner = runners[host] {
+    //            runner.cancel()
+    //        }
+    //        runners[host] = nil
+    //    }
+    //
+    //    /// Returns a Boolean value that indicates whether there is active processing for the host you provide.
+    //    /// - Parameter host: The host to check.
+    //    public func runnerOperating(for host: Host) -> Bool {
+    //        return runners[host] != nil
+    //    }
+    //
+    //    /// Returns the current state of the playbook you provide.
+    //    /// - Parameter playbookId: The ID of the playbook to check.
+    //    /// - Returns: The current state of the execution of the playbook.
+    //    public func status(_ playbookId: Playbook.ID) -> PlaybookStatus? {
+    //        guard let playbook = playbooks[playbookId],
+    //            let state = states[playbookId]
+    //        else {
+    //            return nil
+    //        }
+    //        var hostResults: [Host: [UUID: CommandExecutionResult]] = [:]
+    //        // get a list of all the command IDs for this host in this playbook
+    //        // public let results: [Host:[Command.ID:CommandExecutionResult]]
+    //
+    //        for host in playbook.hosts {
+    //            var resultsForHost: [UUID: CommandExecutionResult] = [:]
+    //            // ALL results from the engine for this host
+    //            if let allEngineResults: [UUID: CommandExecutionResult] = commandResults[host] {
+    //                // only include the results for commands from this playbook
+    //                for commandId in playbook.commands.map(\.id) {
+    //                    if let executionResult = allEngineResults[commandId] {
+    //                        resultsForHost[commandId] = executionResult
+    //                    }
+    //                }
+    //            }
+    //            hostResults[host] = resultsForHost
+    //        }
+    //        return PlaybookStatus(state: state, playbook: playbook, results: hostResults)
+    //    }
+    //
+    //    // MARK: Coordination API
+    //
+    //    func availableCommandsForHost(host: Host) -> [(any Command, Playbook.ID)] {
+    //        var availableCommands: [(any Command, Playbook.ID)] = []
+    //        // list of playbooks that are either scheduled or running
+    //        // but not terminated, failed, or cancelled.
+    //        let availablePlaybookIds: [Playbook.ID] = playbooks.keys.filter { id in
+    //            // return true for isIncluded
+    //            guard let playbookStatus = states[id] else {
+    //                return false
+    //            }
+    //            if playbookStatus == .scheduled || playbookStatus == .running {
+    //                return true
+    //            }
+    //            return false
+    //        }
+    //        for playbookId in availablePlaybookIds {
+    //            guard let playbook = playbooks[playbookId] else {
+    //                continue
+    //            }
+    //            let completedCommandIDs: [UUID] = commandResults[host]?.keys.map { $0 } ?? []
+    //            let remainingCommands: [(any Command)] = playbook.commands.filter { command in
+    //                return !completedCommandIDs.contains(command.id)
+    //            }
+    //            for command in remainingCommands {
+    //                availableCommands.append((command, playbookId))
+    //            }
+    //        }
+    //        return availableCommands
+    //    }
+    //
+    //    func acceptResult(host: Host, result: CommandExecutionResult) {
+    //        // store the result
+    //        if var hostResultDict: [UUID: CommandExecutionResult] = commandResults[host] {
+    //            assert(hostResultDict[result.command.id] == nil, "Duplicate command result")
+    //            hostResultDict[result.command.id] = result
+    //            commandResults[host] = hostResultDict
+    //        } else {
+    //            // dictionary doesn't exist, create it and add result
+    //            commandResults[host] = [result.command.id: result]
+    //        }
+    //        // If the result has a playbook associated with it, update the playbook state
+    //        if let playbookId = result.playbookId {
+    //            // advance the state to running if it wasn't before
+    //            if states[playbookId] == .scheduled {
+    //                states[playbookId] = .running
+    //                stateContinuation.yield((playbookId, .running))
+    //            }
+    //            // if the result is failure, terminate the playbook unless its marked to be ignored
+    //            if result.output.returnCode != 0 && !result.command.ignoreFailure {
+    //                states[playbookId] = .failed
+    //                stateContinuation.yield((playbookId, .failed))
+    //            } else {
+    //                if result.command.id == playbooks[playbookId]?.commands.last?.id {
+    //                    // check for completion
+    //                    if playbookComplete(playbookId: playbookId) {
+    //                        states[playbookId] = .complete
+    //                        stateContinuation.yield((playbookId, .complete))
+    //                    }
+    //                }
+    //            }
+    //        }
+    //        // stream the result as well
+    //        commandContinuation.yield(result)
+    //    }
+    //
+    //    func playbookComplete(playbookId: Playbook.ID) -> Bool {
+    //        guard let originalPlaybook = playbooks[playbookId] else {
+    //            return false
+    //        }
+    //        for host in originalPlaybook.hosts {
+    //            guard let commandResultsForHost = commandResults[host],
+    //                commandResultsForHost.count == originalPlaybook.commands.count
+    //            else {
+    //                return false
+    //            }
+    //            // host has all commands reported from original playbook
+    //            let anyFailure = commandResultsForHost.contains { (id: UUID, result: CommandExecutionResult) in
+    //                result.output.returnCode != 0 && !result.command.ignoreFailure
+    //            }
+    //            if anyFailure {
+    //                return false
+    //            }
+    //        }
+    //        return true
+    //    }
+    //
+    //    func handleCommandException(
+    //        playbookId: Playbook.ID, host: Host, command: (any Command), exception: any Error
+    //    ) {
+    //        // store the result
+    //        let exceptionReport = CommandExecutionResult(
+    //            command: command, host: host, playbookId: playbookId, output: .empty, duration: .nanoseconds(0), retries: 0,
+    //            exception: exception.localizedDescription)
+    //        if var hostResultDict: [UUID: CommandExecutionResult] = commandResults[host] {
+    //            assert(hostResultDict[command.id] == nil, "Duplicate command result")
+    //            hostResultDict[command.id] = exceptionReport
+    //            commandResults[host] = hostResultDict
+    //        } else {
+    //            // dictionary doesn't exist, create it and add result
+    //            commandResults[host] = [command.id: exceptionReport]
+    //        }
+    //        states[playbookId] = .failed
+    //        stateContinuation.yield((playbookId, .failed))
+    //        // stream the result as well
+    //        commandContinuation.yield(exceptionReport)
+    //    }
 
     // MARK: Running API
 
-    /// Runs the next command in the background that is available for the host you provide.
-    /// - Parameter host: The host to interact with.
-    public nonisolated func step(for host: Host) async {
-        // `nonisolated` + `async` means run on a cooperative thread pool and return the result
-        // remove the `nonisolated` keyword to run in the actor's context.
-        let availableCommands = await availableCommandsForHost(host: host)
-        if let (nextCommand, playbookId) = availableCommands.first {
-            //get and run
-            do {
-                let commandResult = try await run(command: nextCommand, host: host, playbookId: playbookId)
-                await acceptResult(host: host, result: commandResult)
-            } catch {
-                await handleCommandException(playbookId: playbookId, host: host, command: nextCommand, exception: error)
-            }
-        }
-    }
+    //    /// Runs the next command in the background that is available for the host you provide.
+    //    /// - Parameter host: The host to interact with.
+    //    public nonisolated func step(for host: Host) async {
+    //        // `nonisolated` + `async` means run on a cooperative thread pool and return the result
+    //        // remove the `nonisolated` keyword to run in the actor's context.
+    //        let availableCommands = await availableCommandsForHost(host: host)
+    //        if let (nextCommand, playbookId) = availableCommands.first {
+    //            //get and run
+    //            do {
+    //                let commandResult = try await run(command: nextCommand, host: host, playbookId: playbookId)
+    //                await acceptResult(host: host, result: commandResult)
+    //            } catch {
+    //                await handleCommandException(playbookId: playbookId, host: host, command: nextCommand, exception: error)
+    //            }
+    //        }
+    //    }
 
     /// Directly runs a series of commands against a single host.
     /// - Parameters:

--- a/Tests/formicTests/EngineTests.swift
+++ b/Tests/formicTests/EngineTests.swift
@@ -6,27 +6,27 @@ import Testing
 
 @Test("Engine initializer")
 func initEngine() async throws {
-    let engine = Engine()
+    let _ = Engine()
 
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.commandResults.isEmpty)
-    #expect(await engine.playbooks.isEmpty)
-    #expect(await engine.states.isEmpty)
-
-    // external/public API
-    #expect(await engine.runnerOperating(for: .localhost) == false)
-    #expect(await engine.status(UUID()) == nil)
-
-    // internal pieces
-    #expect(await engine.availableCommandsForHost(host: .localhost).isEmpty)
-
-    // step with no playbooks is a no-op
-    await engine.step(for: .localhost)
-
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.commandResults.isEmpty)
-    #expect(await engine.playbooks.isEmpty)
-    #expect(await engine.states.isEmpty)
+    //    #expect(await engine.runners.count == 0)
+    //    #expect(await engine.commandResults.isEmpty)
+    //    #expect(await engine.playbooks.isEmpty)
+    //    #expect(await engine.states.isEmpty)
+    //
+    //    // external/public API
+    //    #expect(await engine.runnerOperating(for: .localhost) == false)
+    //    #expect(await engine.status(UUID()) == nil)
+    //
+    //    // internal pieces
+    //    #expect(await engine.availableCommandsForHost(host: .localhost).isEmpty)
+    //
+    //    // step with no playbooks is a no-op
+    //    await engine.step(for: .localhost)
+    //
+    //    #expect(await engine.runners.count == 0)
+    //    #expect(await engine.commandResults.isEmpty)
+    //    #expect(await engine.playbooks.isEmpty)
+    //    #expect(await engine.states.isEmpty)
 }
 
 @Test("Direct engine execution - single function")
@@ -190,426 +190,426 @@ func testEngineRunPlaybookWithException() async throws {
             }
         })
 }
-
-@Test("engine schedule w/ step function")
-func testEngineScheduleStep() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addSuccess(command: ["whoami"], presentOutput: "docker-user")
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-
-        #expect(await engine.runners.count == 0)
-        #expect(await engine.commandResults.count == 1)
-        #expect(await engine.commandResults[fakeHost] == [:])
-        #expect(await engine.playbooks.count == 1)
-        #expect(await engine.playbooks[playbook.id] == playbook)
-        #expect(await engine.states.count == 1)
-        #expect(await engine.states[playbook.id] == .scheduled)
-    }
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        // and take a _single_ step
-        await engine.step(for: fakeHost)
-    }
-
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.commandResults.count == 1)
-    #expect(await engine.playbooks.count == 1)
-    #expect(await engine.playbooks[playbook.id] == playbook)
-    #expect(await engine.states.count == 1)
-    let playbookRunState = try #require(await engine.states[playbook.id])
-    #expect(playbookRunState == .running)
-
-    // and verify the results of the first command are recorded
-    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
-    #expect(currentResults.count == 1)
-    let singleResult: CommandExecutionResult = try #require(currentResults[cmd1.id])
-    #expect(singleResult.command.id == cmd1.id)
-    #expect(singleResult.playbookId == playbook.id)
-    #expect(singleResult.host == fakeHost)
-    #expect(singleResult.retries == 0)
-}
-
-@Test("engine schedule w/ step function")
-func testEngineScheduleStepWithFailure() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addFailure(command: ["whoami"], presentOutput: "zsh: command not found: whoami")
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-        await engine.step(for: fakeHost)
-        await engine.step(for: fakeHost)
-    }
-
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.playbooks.count == 1)
-    #expect(await engine.playbooks[playbook.id] == playbook)
-    #expect(await engine.states.count == 1)
-
-    let playbookRunState = try #require(await engine.states[playbook.id])
-    #expect(playbookRunState == .failed)
-
-    #expect(await engine.commandResults.count == 1)
-
-    // and verify the results of the first command are recorded
-    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
-    #expect(currentResults.count == 2)
-    let finalResult: CommandExecutionResult = try #require(currentResults[cmd2.id])
-    #expect(finalResult.command.id == cmd2.id)
-    #expect(finalResult.playbookId == playbook.id)
-    #expect(finalResult.host == fakeHost)
-    #expect(finalResult.retries == 0)
-
-    #expect(finalResult.output.returnCode == -1)
-    #expect(finalResult.output.stderrString == "zsh: command not found: whoami")
-}
-
-@Test("playbook complete w/ step function")
-func testPlaybookComplete() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost, .localhost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addSuccess(command: ["whoami"], presentOutput: "zsh: command not found: whoami")
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
-        await engine.step(for: fakeHost)
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
-        await engine.step(for: fakeHost)
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
-        await engine.step(for: .localhost)
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
-        await engine.step(for: .localhost)
-        #expect(await engine.playbookComplete(playbookId: playbook.id) == true)
-    }
-}
-
-@Test("playbook result for non-existant playbook")
-func testUnknownPlaybookComplete() async throws {
-    let engine = Engine()
-    let unregisteredPlaybook = await Playbook(name: "unknown", hosts: [], commands: [])
-    #expect(await engine.playbookComplete(playbookId: unregisteredPlaybook.id) == false)
-}
-
-@Test("engine schedule w/ immediate error using step function")
-func testEngineScheduleStepWithImmediateError() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addException(command: ["uname"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-
-        #expect(await engine.runners.count == 0)
-        #expect(await engine.commandResults.count == 1)
-        #expect(await engine.commandResults[fakeHost] == [:])
-        #expect(await engine.playbooks.count == 1)
-        #expect(await engine.playbooks[playbook.id] == playbook)
-        #expect(await engine.states.count == 1)
-        #expect(await engine.states[playbook.id] == .scheduled)
-    }
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        // and take a _single_ step
-        await engine.step(for: fakeHost)
-    }
-
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.commandResults.count == 1)
-    #expect(await engine.playbooks.count == 1)
-    #expect(await engine.playbooks[playbook.id] == playbook)
-    #expect(await engine.states.count == 1)
-
-    let playbookRunState = try #require(await engine.states[playbook.id])
-    #expect(playbookRunState == .failed)
-
-    // and verify the results of the first command are recorded
-    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
-    #expect(currentResults.count == 1)
-}
-
-@Test("engine schedule, later exception, w/ step function")
-func testEngineScheduleStepWithLaterException() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-        await engine.step(for: fakeHost)
-        await engine.step(for: fakeHost)
-    }
-
-    #expect(await engine.runners.count == 0)
-    #expect(await engine.playbooks.count == 1)
-    #expect(await engine.playbooks[playbook.id] == playbook)
-    #expect(await engine.states.count == 1)
-
-    let playbookRunState = try #require(await engine.states[playbook.id])
-    #expect(playbookRunState == .failed)
-
-    #expect(await engine.commandResults.count == 1)
-
-    // and verify the results of the first command are recorded
-    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
-    #expect(currentResults.count == 2)
-
-    let finalResult: CommandExecutionResult = try #require(currentResults[cmd2.id])
-    #expect(finalResult.command.id == cmd2.id)
-    #expect(finalResult.playbookId == playbook.id)
-    #expect(finalResult.host == fakeHost)
-    #expect(finalResult.exception == "Unknown error: Process failed in something")
-}
-
-@Test("requesting state after single step")
-func testPlaybookStatusAfterStep() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addSuccess(command: ["whoami"], presentOutput: "docker-user")
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-        await engine.step(for: fakeHost)
-    }
-
-    let pbStatus: PlaybookStatus = try #require(await engine.status(playbook.id))
-    #expect(pbStatus.playbook == playbook)
-    #expect(pbStatus.state == .running)
-    #expect(!pbStatus.results.isEmpty)
-    let resultsFromPbStatus = pbStatus.results
-    #expect(resultsFromPbStatus.count == 1)
-    let dictOfResultsforHost: [UUID: CommandExecutionResult] = try #require(resultsFromPbStatus[fakeHost])
-    #expect(dictOfResultsforHost.count == 1)
-    #expect(dictOfResultsforHost[cmd1.id]?.command.id == cmd1.id)
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.step(for: fakeHost)
-    }
-
-    let finalPbStatus: PlaybookStatus = try #require(await engine.status(playbook.id))
-    #expect(finalPbStatus.state == .complete)
-}
-
-@Test("using Schedule, default mode, creates a runner for the hosts of the playbook scheduled")
-func testPlaybookRunnerIsCreatedOnSchedule() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [])
-
-    await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: true)
-    }
-
-    #expect(await engine.runners.count == 1)
-    await engine.cancelRunner(for: fakeHost)
-    #expect(await engine.runners.count == 0)
-}
-
-@Test("verify playbook state stream")
-func testPlaybookStateStream() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
-
-    let stateStream: AsyncStream<(Playbook.ID, PlaybookState)> = engine.playbookUpdates
-    var streamIterator = stateStream.makeAsyncIterator()
-
-    try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-
-        var (id, state) = try #require(await streamIterator.next())
-        #expect(id == playbook.id)
-        #expect(state == .scheduled)
-
-        await engine.step(for: fakeHost)
-
-        (id, state) = try #require(await streamIterator.next())
-        #expect(id == playbook.id)
-        #expect(state == .running)
-
-        await engine.step(for: fakeHost)
-        (id, state) = try #require(await streamIterator.next())
-        #expect(id == playbook.id)
-        #expect(state == .failed)
-    }
-}
-
-@Test("verify playbook command result stream")
-func testPlaybookCommandResultStream() async throws {
-    typealias Host = Formic.Host
-    let engine = Engine()
-    let cmd1 = ShellCommand("uname")
-    let cmd2 = ShellCommand("whoami")
-
-    let fakeHost = try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess(
-            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
-    } operation: {
-        try await Host.resolve("somewhere.com")
-    }
-
-    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
-    let mockCmdInvoker = TestCommandInvoker()
-        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
-        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
-
-    let stateStream: AsyncStream<CommandExecutionResult> = engine.commandUpdates
-    var streamIterator = stateStream.makeAsyncIterator()
-
-    try await withDependencies { dependencyValues in
-        dependencyValues.localSystemAccess = TestFileSystemAccess()
-        dependencyValues.commandInvoker = mockCmdInvoker
-    } operation: {
-        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
-
-        await engine.step(for: fakeHost)
-
-        var result: CommandExecutionResult = try #require(await streamIterator.next())
-        #expect(result.playbookId == playbook.id)
-        #expect(result.exception == nil)
-        #expect(result.command.id == cmd1.id)
-
-        await engine.step(for: fakeHost)
-        result = try #require(await streamIterator.next())
-        #expect(result.playbookId == playbook.id)
-        #expect(result.exception != nil)
-        #expect(result.command.id == cmd2.id)
-    }
-}
+//
+//@Test("engine schedule w/ step function")
+//func testEngineScheduleStep() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addSuccess(command: ["whoami"], presentOutput: "docker-user")
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//
+//        #expect(await engine.runners.count == 0)
+//        #expect(await engine.commandResults.count == 1)
+//        #expect(await engine.commandResults[fakeHost] == [:])
+//        #expect(await engine.playbooks.count == 1)
+//        #expect(await engine.playbooks[playbook.id] == playbook)
+//        #expect(await engine.states.count == 1)
+//        #expect(await engine.states[playbook.id] == .scheduled)
+//    }
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        // and take a _single_ step
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    #expect(await engine.runners.count == 0)
+//    #expect(await engine.commandResults.count == 1)
+//    #expect(await engine.playbooks.count == 1)
+//    #expect(await engine.playbooks[playbook.id] == playbook)
+//    #expect(await engine.states.count == 1)
+//    let playbookRunState = try #require(await engine.states[playbook.id])
+//    #expect(playbookRunState == .running)
+//
+//    // and verify the results of the first command are recorded
+//    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
+//    #expect(currentResults.count == 1)
+//    let singleResult: CommandExecutionResult = try #require(currentResults[cmd1.id])
+//    #expect(singleResult.command.id == cmd1.id)
+//    #expect(singleResult.playbookId == playbook.id)
+//    #expect(singleResult.host == fakeHost)
+//    #expect(singleResult.retries == 0)
+//}
+//
+//@Test("engine schedule w/ step function")
+//func testEngineScheduleStepWithFailure() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addFailure(command: ["whoami"], presentOutput: "zsh: command not found: whoami")
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//        await engine.step(for: fakeHost)
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    #expect(await engine.runners.count == 0)
+//    #expect(await engine.playbooks.count == 1)
+//    #expect(await engine.playbooks[playbook.id] == playbook)
+//    #expect(await engine.states.count == 1)
+//
+//    let playbookRunState = try #require(await engine.states[playbook.id])
+//    #expect(playbookRunState == .failed)
+//
+//    #expect(await engine.commandResults.count == 1)
+//
+//    // and verify the results of the first command are recorded
+//    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
+//    #expect(currentResults.count == 2)
+//    let finalResult: CommandExecutionResult = try #require(currentResults[cmd2.id])
+//    #expect(finalResult.command.id == cmd2.id)
+//    #expect(finalResult.playbookId == playbook.id)
+//    #expect(finalResult.host == fakeHost)
+//    #expect(finalResult.retries == 0)
+//
+//    #expect(finalResult.output.returnCode == -1)
+//    #expect(finalResult.output.stderrString == "zsh: command not found: whoami")
+//}
+//
+//@Test("playbook complete w/ step function")
+//func testPlaybookComplete() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost, .localhost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addSuccess(command: ["whoami"], presentOutput: "zsh: command not found: whoami")
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
+//        await engine.step(for: fakeHost)
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
+//        await engine.step(for: fakeHost)
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
+//        await engine.step(for: .localhost)
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == false)
+//        await engine.step(for: .localhost)
+//        #expect(await engine.playbookComplete(playbookId: playbook.id) == true)
+//    }
+//}
+//
+//@Test("playbook result for non-existant playbook")
+//func testUnknownPlaybookComplete() async throws {
+//    let engine = Engine()
+//    let unregisteredPlaybook = await Playbook(name: "unknown", hosts: [], commands: [])
+//    #expect(await engine.playbookComplete(playbookId: unregisteredPlaybook.id) == false)
+//}
+//
+//@Test("engine schedule w/ immediate error using step function")
+//func testEngineScheduleStepWithImmediateError() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addException(command: ["uname"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//
+//        #expect(await engine.runners.count == 0)
+//        #expect(await engine.commandResults.count == 1)
+//        #expect(await engine.commandResults[fakeHost] == [:])
+//        #expect(await engine.playbooks.count == 1)
+//        #expect(await engine.playbooks[playbook.id] == playbook)
+//        #expect(await engine.states.count == 1)
+//        #expect(await engine.states[playbook.id] == .scheduled)
+//    }
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        // and take a _single_ step
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    #expect(await engine.runners.count == 0)
+//    #expect(await engine.commandResults.count == 1)
+//    #expect(await engine.playbooks.count == 1)
+//    #expect(await engine.playbooks[playbook.id] == playbook)
+//    #expect(await engine.states.count == 1)
+//
+//    let playbookRunState = try #require(await engine.states[playbook.id])
+//    #expect(playbookRunState == .failed)
+//
+//    // and verify the results of the first command are recorded
+//    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
+//    #expect(currentResults.count == 1)
+//}
+//
+//@Test("engine schedule, later exception, w/ step function")
+//func testEngineScheduleStepWithLaterException() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//        await engine.step(for: fakeHost)
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    #expect(await engine.runners.count == 0)
+//    #expect(await engine.playbooks.count == 1)
+//    #expect(await engine.playbooks[playbook.id] == playbook)
+//    #expect(await engine.states.count == 1)
+//
+//    let playbookRunState = try #require(await engine.states[playbook.id])
+//    #expect(playbookRunState == .failed)
+//
+//    #expect(await engine.commandResults.count == 1)
+//
+//    // and verify the results of the first command are recorded
+//    let currentResults: [UUID: CommandExecutionResult] = try await #require(engine.commandResults[fakeHost])
+//    #expect(currentResults.count == 2)
+//
+//    let finalResult: CommandExecutionResult = try #require(currentResults[cmd2.id])
+//    #expect(finalResult.command.id == cmd2.id)
+//    #expect(finalResult.playbookId == playbook.id)
+//    #expect(finalResult.host == fakeHost)
+//    #expect(finalResult.exception == "Unknown error: Process failed in something")
+//}
+//
+//@Test("requesting state after single step")
+//func testPlaybookStatusAfterStep() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addSuccess(command: ["whoami"], presentOutput: "docker-user")
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    let pbStatus: PlaybookStatus = try #require(await engine.status(playbook.id))
+//    #expect(pbStatus.playbook == playbook)
+//    #expect(pbStatus.state == .running)
+//    #expect(!pbStatus.results.isEmpty)
+//    let resultsFromPbStatus = pbStatus.results
+//    #expect(resultsFromPbStatus.count == 1)
+//    let dictOfResultsforHost: [UUID: CommandExecutionResult] = try #require(resultsFromPbStatus[fakeHost])
+//    #expect(dictOfResultsforHost.count == 1)
+//    #expect(dictOfResultsforHost[cmd1.id]?.command.id == cmd1.id)
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.step(for: fakeHost)
+//    }
+//
+//    let finalPbStatus: PlaybookStatus = try #require(await engine.status(playbook.id))
+//    #expect(finalPbStatus.state == .complete)
+//}
+//
+//@Test("using Schedule, default mode, creates a runner for the hosts of the playbook scheduled")
+//func testPlaybookRunnerIsCreatedOnSchedule() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [])
+//
+//    await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: true)
+//    }
+//
+//    #expect(await engine.runners.count == 1)
+//    await engine.cancelRunner(for: fakeHost)
+//    #expect(await engine.runners.count == 0)
+//}
+
+//@Test("verify playbook state stream")
+//func testPlaybookStateStream() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
+//
+//    let stateStream: AsyncStream<(Playbook.ID, PlaybookState)> = engine.playbookUpdates
+//    var streamIterator = stateStream.makeAsyncIterator()
+//
+//    try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//
+//        var (id, state) = try #require(await streamIterator.next())
+//        #expect(id == playbook.id)
+//        #expect(state == .scheduled)
+//
+//        await engine.step(for: fakeHost)
+//
+//        (id, state) = try #require(await streamIterator.next())
+//        #expect(id == playbook.id)
+//        #expect(state == .running)
+//
+//        await engine.step(for: fakeHost)
+//        (id, state) = try #require(await streamIterator.next())
+//        #expect(id == playbook.id)
+//        #expect(state == .failed)
+//    }
+//}
+//
+//@Test("verify playbook command result stream")
+//func testPlaybookCommandResultStream() async throws {
+//    typealias Host = Formic.Host
+//    let engine = Engine()
+//    let cmd1 = ShellCommand("uname")
+//    let cmd2 = ShellCommand("whoami")
+//
+//    let fakeHost = try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess(
+//            dnsName: "somewhere.com", ipAddressesToUse: ["8.8.8.8"])
+//    } operation: {
+//        try await Host.resolve("somewhere.com")
+//    }
+//
+//    let playbook = Playbook(name: "example", hosts: [fakeHost], commands: [cmd1, cmd2])
+//    let mockCmdInvoker = TestCommandInvoker()
+//        .addSuccess(command: ["uname"], presentOutput: "Linux\n")
+//        .addException(command: ["whoami"], errorToThrow: TestError.unknown(msg: "Process failed in something"))
+//
+//    let stateStream: AsyncStream<CommandExecutionResult> = engine.commandUpdates
+//    var streamIterator = stateStream.makeAsyncIterator()
+//
+//    try await withDependencies { dependencyValues in
+//        dependencyValues.localSystemAccess = TestFileSystemAccess()
+//        dependencyValues.commandInvoker = mockCmdInvoker
+//    } operation: {
+//        await engine.schedule(playbook, delay: .microseconds(1), startRunner: false)
+//
+//        await engine.step(for: fakeHost)
+//
+//        var result: CommandExecutionResult = try #require(await streamIterator.next())
+//        #expect(result.playbookId == playbook.id)
+//        #expect(result.exception == nil)
+//        #expect(result.command.id == cmd1.id)
+//
+//        await engine.step(for: fakeHost)
+//        result = try #require(await streamIterator.next())
+//        #expect(result.playbookId == playbook.id)
+//        #expect(result.exception != nil)
+//        #expect(result.command.id == cmd2.id)
+//    }
+//}
 
 @Test("verify timeout is triggered on long command")
 func testCommandTimeout() async throws {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -6,7 +6,118 @@ For a starting point, enable maybe a type that is either an [AsyncParsableComman
 
 Structure playbooks **in Swift**, leveraging type safety and structured Resources.
 
-an example declarative playlist:
+A couple example playbooks:
+
+```swift
+let createDockerHost = Playbook(name: "apply pending upgrades", hosts: hosts, commands: [
+    ShellCommand("sudo apt-get update -q"),
+    ShellCommand("sudo apt-get upgrade -y"),
+])
+```
+
+```swift
+import Foundation
+import ArgumentParser
+import Formic
+typealias Host = Formic.Host
+
+@main
+struct configureBastion: AsyncParsableCommand {
+    @Argument(help: "The network address of the host to update") var netAddress: Host.NetworkAddress
+    @Option(name: .shortAndLong, help: "The user to connect as") var user: String = "docker-user"
+    @Option(name: .shortAndLong, help: "The port to connect through") var port: Int = 22  // default ssh port
+    @Option(name: .long, help: "The identity file to use") var identityFile: String? = nil
+
+    @Argument(help: "The path to the private SSH key to copy") var privateKeyLocation: String
+
+    @Flag(name: .shortAndLong, help: "Run in verbose mode") var verbose: Bool = false
+
+    mutating func run() async throws {
+        let keyName = URL(fileURLWithPath: privateKeyLocation).lastPathComponent
+        let netHost: Host = try Host(netAddress, sshPort: port, sshUser: user, sshIdentityFile: identityFile)
+        let setupSSHKey = Playbook(name: "install SSH private key", hosts: [netHost], commands: [
+            ShellCommand("mkdir -p ~/.ssh"),
+            ShellCommand("chmod 0700 ~/.ssh"),
+            CopyInto(location: privateKeyLocation, from: "~/.ssh/\(keyName)"),
+            ShellCommand("chmod 0600 ~/.ssh/\(keyName)"),
+        ])
+        let verbosity: Verbosity = verbose ? .verbose(emoji: true) : .normal(emoji: true)
+        try await Engine().run(playbook: setupSSHKey, displayProgress: true, verbosity: verbosity)
+    }
+}
+```
+
+Host -> RemoteHost?, OS?, NetHost? - host seems overloaded, as well as a type already in Foundation, which is causing some confusion. Just NetworkAddress?
+I need this for ShellCommand in particular, but otherwise it's really about the network address to uniquely
+identify the location to work with.
+
+ShellCommand() -> SHCmd(), Cmd() // for brevity?
+
+### Resources
+
+ideas for what declarative versions might look like:
+
+```swift
+let packages = DebianPackage.query(host)
+let packages = DebianPackage.find(host)
+apply { host in
+    Package("docker.io", state: absent)
+    Package("curl", state: present)
+    Package("ca-certificates", state: present)  // alternately: "installed | removed" ?
+    User("docker-user", inGroup: "docker", state: enabled) // alternately: "exists | absent" ?
+    Directory("/etc/apt/keyrings", mode: 0755, state: present)
+    CopyFrom(location: "/etc/apt/keyrings/docker.asc", from "https://download.docker.com/linux/ubuntu/gpg")
+    let arch = DebianPackage(host).architecture
+    
+    // install remote apt repo
+    // echo \
+  // "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  // $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  // sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  
+    Package("docker-ce", installed: true)
+    
+    let envset = ENVSET("/etc/os-release")
+}
+```
+```bash
+docker-user@ubuntu:~$ cat /etc/os-release
+PRETTY_NAME="Ubuntu 24.04.1 LTS"
+NAME="Ubuntu"
+VERSION_ID="24.04"
+VERSION="24.04.1 LTS (Noble Numbat)"
+VERSION_CODENAME=noble
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=noble
+LOGO=ubuntu-logo
+
+docker-user@ubuntu:~$ cat /etc/lsb-release
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=24.04
+DISTRIB_CODENAME=noble
+DISTRIB_DESCRIPTION="Ubuntu 24.04.1 LTS"
+```
+
+
+```swift
+struct MyPlaylist: AsyncParsableCommand {
+  @Argument host: String
+  @Option user: String?
+  ...
+  func run() async {
+    let myHost = Host(ip: host)
+    myHost.apply() {
+      allAvailableUpdatesInstalled(securityOnly: true)
+      DockerNode(state: enabled, service: active, forUser: user)
+    }
+  }
+}
+```
 
 ```swift
 struct MyPlaylist: AsyncParsableCommand {


### PR DESCRIPTION
Noodling on what it might work/look like with declarative resources, and gutting existing background scheduling setup to allow for a re-think of how to arrange things allowing from cross-host coordination, specifically for resources that span multiple hosts (docker swarm, database cluster, etc)