### PR TITLE
breaking up resource from requiring a command defined on it

### DIFF
--- a/Sources/Formic/Documentation.docc/Documentation.md
+++ b/Sources/Formic/Documentation.docc/Documentation.md
@@ -41,6 +41,7 @@ Quite a is inspired by [Ansible](https://github.com/ansible/ansible), with a goa
 - ``Dpkg``
 
 - ``Resource``
+- ``ParsedResource``
 - ``StatefulResource``
 
 ### Singular Resources

--- a/Sources/Formic/Resources/CollectionResource.swift
+++ b/Sources/Formic/Resources/CollectionResource.swift
@@ -2,7 +2,7 @@ import Dependencies
 import Foundation
 
 /// A collection of resources that can be found and queried from a host.
-public protocol CollectionResource: Resource {
+public protocol CollectionResource: ParsedResource {
     /// The shell command to use to get the state for this resource.
     static var collectionInquiry: (any Command) { get }
     /// Returns a list of resources from the string output from a command.

--- a/Sources/Formic/Resources/Resource.swift
+++ b/Sources/Formic/Resources/Resource.swift
@@ -1,23 +1,27 @@
 import Dependencies
 import Foundation
 
-/// A type of resource that can be updated from a remote and supports collections and persistence.
+/// A type that can be queried from a host to provide information about itself.
 public protocol Resource: Hashable, Sendable {
 
     // IMPLEMENTATION NOTE:
     // A resource is fundamentally something you can query about a system to get details about it.
     // Any **instance** of a resource should be able to get updated details about itself.
 
+    /// Queries the state of the resource from the given host.
+    /// - Parameter from: The host to inspect.
+    /// - Returns: The state of the resource.
+    func query(from: Host) async throws -> (Self, Date)
+}
+
+/// A resource that provides an inquiry command and parser to return the state of the resource.
+public protocol ParsedResource: Resource {
     /// The command to use to get the state for this resource.
     var inquiry: (any Command) { get }
     /// Returns the state of the resource from the output of the shell command.
     /// - Parameter output: The string output of the shell command.
     /// - Throws: Any errors parsing the output.
     static func parse(_ output: Data) throws -> Self
-    /// Queries the state of the resource from the given host.
-    /// - Parameter from: The host to inspect.
-    /// - Returns: The state of the resource.
-    func query(from: Host) async throws -> (Self, Date)
 }
 
 // IMPLEMENTATION NOTE:
@@ -47,7 +51,7 @@ public protocol Resource: Hashable, Sendable {
 // (I think a single command will do what we need for resources within an OS, but for resources
 // that span multiple hosts, we will need something different)
 
-extension Resource {
+extension ParsedResource {
     /// Queries the state of the resource from the given host.
     /// - Parameter host: The host to inspect.
     /// - Returns: The state of the resource and the time that it was last updated.

--- a/Sources/Formic/Resources/SingularResource.swift
+++ b/Sources/Formic/Resources/SingularResource.swift
@@ -2,7 +2,7 @@ import Dependencies
 import Foundation
 
 /// A type of resource that exists in singular form on a Host.
-public protocol SingularResource: Resource {
+public protocol SingularResource: ParsedResource {
 
     // a singular resource should have a way to query for the kind of resource given
     // JUST the host, so any default query & parse setup should be accessible as


### PR DESCRIPTION
## Description
A core resource definition should be simpler and not require a single command on it, or a parser. 

## Motivation and Context
It's a convenience that doesn't work for cluster resources.
resolves #58 

## How has this been tested?
maintain all tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected. Examples include renaming parameters in public API, removing public API, or adding a new parameter to public API without a default value.)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
