### PR TITLE
shifting exception capture to allow for retry

### DIFF
--- a/Sources/Formic/CommandOutput.swift
+++ b/Sources/Formic/CommandOutput.swift
@@ -52,6 +52,12 @@ public struct CommandOutput: Sendable {
     public static func generalFailure(msg: String) -> CommandOutput {
         CommandOutput(returnCode: -1, stdOut: nil, stdErr: msg.data(using: .utf8))
     }
+
+    /// Creates a command out that represents an exception thrown failure, and has no output.
+    public static func exceptionFailure() -> CommandOutput {
+        CommandOutput(returnCode: -1, stdOut: nil, stdErr: nil)
+    }
+
 }
 
 extension CommandOutput: Hashable {}

--- a/Sources/Formic/Engine/CommandExecutionResult.swift
+++ b/Sources/Formic/Engine/CommandExecutionResult.swift
@@ -78,9 +78,11 @@ extension CommandExecutionResult {
                 if includeEmoji {
                     stringOutput.append(" ")
                 }
+                stringOutput.append("[\(formattedDuration)] ")
                 stringOutput.append("exception: \(exception)")
             } else if output.returnCode != 0 {
                 stringOutput.append("command: \(command), rc=\(output.returnCode), retries=\(retries)")
+                stringOutput.append("[\(formattedDuration)] ")
                 if let errorOutput = output.stderrString {
                     stringOutput.append("\nSTDERR: \(errorOutput)")
                 } else {
@@ -88,6 +90,7 @@ extension CommandExecutionResult {
                 }
             } else {
                 stringOutput.append("command: \(command), rc=\(output.returnCode), retries=\(retries)")
+                stringOutput.append("[\(formattedDuration)] ")
             }
         case .verbose(emoji: let includeEmoji):
             // Reports host, command, duration, the result code, and stdout on success, or stderr on failure.
@@ -98,6 +101,7 @@ extension CommandExecutionResult {
                 if includeEmoji {
                     stringOutput.append(" ")
                 }
+                stringOutput.append("[\(formattedDuration)] ")
                 stringOutput.append("exception: \(exception)")
             } else if output.returnCode != 0 {
                 stringOutput.append("[\(formattedDuration)] ")
@@ -125,6 +129,7 @@ extension CommandExecutionResult {
                 if includeEmoji {
                     stringOutput.append(" ")
                 }
+                stringOutput.append("[\(formattedDuration)] ")
                 stringOutput.append("exception: \(exception)")
             } else {
                 stringOutput.append("[\(formattedDuration)] ")

--- a/Sources/Formic/Engine/CommandExecutionResult.swift
+++ b/Sources/Formic/Engine/CommandExecutionResult.swift
@@ -11,7 +11,7 @@ public struct CommandExecutionResult: Sendable {
     /// The number of retries needed for the command.
     public let retries: Int
     /// The description of the exception thrown while invoking the command, if any.
-    public let exception: String?
+    public let exception: (any Error)?
 
     /// Creates an annotated command execution result.
     /// - Parameters:
@@ -23,7 +23,7 @@ public struct CommandExecutionResult: Sendable {
     ///   - exception: The description of the exception thrown while invoking the command, if any.
     public init(
         command: any Command, host: Host, output: CommandOutput, duration: Duration,
-        retries: Int, exception: String?
+        retries: Int, exception: (any Error)?
     ) {
         self.command = command
         self.host = host
@@ -163,7 +163,7 @@ extension CommandExecutionResult: Equatable {
     public static func == (lhs: CommandExecutionResult, rhs: CommandExecutionResult) -> Bool {
         lhs.command.id == rhs.command.id && lhs.host == rhs.host
             && lhs.output == rhs.output && lhs.duration == rhs.duration && lhs.retries == rhs.retries
-            && lhs.exception == rhs.exception
+            && lhs.exception?.localizedDescription == rhs.exception?.localizedDescription
     }
 }
 
@@ -177,6 +177,6 @@ extension CommandExecutionResult: Hashable {
         hasher.combine(output)
         hasher.combine(duration)
         hasher.combine(retries)
-        hasher.combine(exception)
+        hasher.combine(exception?.localizedDescription)
     }
 }

--- a/Sources/Formic/Engine/Engine.swift
+++ b/Sources/Formic/Engine/Engine.swift
@@ -80,6 +80,7 @@ public actor Engine {
     ///   - host: The host on which to run the command.
     ///   - command: The command to run.
     /// - Returns: The result of the command execution.
+    /// - Throws: exceptions from Task.sleep delay while retrying.
     public nonisolated func run(host: Host, command: (any Command)) async throws
         -> CommandExecutionResult
     {

--- a/Tests/formicTests/CommandExecutionOutputTests.swift
+++ b/Tests/formicTests/CommandExecutionOutputTests.swift
@@ -28,7 +28,8 @@ func testEmojiForExecutionOuput() async throws {
     #expect(
         CommandExecutionResult(
             command: cmd, host: .localhost, output: failureOutput, duration: .milliseconds(1),
-            retries: 0, exception: "Error desc"
+            retries: 0, exception: TestError.unknown(msg: "Error desc")
+
         ).emojiString() == "🚫")
 
 }
@@ -55,7 +56,7 @@ func testConsoleOutputForExecutionOuput() async throws {
 
     let exceptionResult = CommandExecutionResult(
         command: cmd, host: .localhost, output: failureOutput, duration: .milliseconds(1), retries: 0,
-        exception: "exception reported")
+        exception: TestError.unknown(msg: "exception reported"))
 
     //TODO: This is probably more sanely refactored into parameterized tests
 

--- a/Tests/formicTests/CommandExecutionOutputTests.swift
+++ b/Tests/formicTests/CommandExecutionOutputTests.swift
@@ -89,35 +89,50 @@ func testConsoleOutputForExecutionOuput() async throws {
     #expect(successResult.consoleOutput(verbosity: .normal(emoji: false)).contains("uname"))
     #expect(successResult.consoleOutput(verbosity: .normal(emoji: false)).contains("rc=0"))
     #expect(successResult.consoleOutput(verbosity: .normal(emoji: false)).contains("retries=0"))
+    #expect(successResult.consoleOutput(verbosity: .normal(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("I'm not telling you!"))
+    #expect(successResult.consoleOutput(verbosity: .normal(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("I'm not telling you!"))
+    #expect(failureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .normal(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(exceptionResult.consoleOutput(verbosity: .normal(emoji: true)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .normal(emoji: true)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .normal(emoji: true)).contains("[00:00"))
+    // duration marker
+
     #expect(!exceptionResult.consoleOutput(verbosity: .normal(emoji: false)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .normal(emoji: false)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .normal(emoji: false)).contains("[00:00"))
+    // duration marker
 
     // .verbose
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("✅"))
@@ -125,41 +140,58 @@ func testConsoleOutputForExecutionOuput() async throws {
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("rc=0"))
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("retries=0"))
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("✅"))
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("uname"))
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("rc=0"))
     #expect(successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("retries=0"))
-    #expect(successResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("I'm not telling you!"))
+    #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("I'm not telling you!"))
+    #expect(failureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(exceptionResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .verbose(emoji: true)).contains("[00:00"))
+    // duration marker
+
     #expect(!exceptionResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .verbose(emoji: false)).contains("[00:00"))
+    // duration marker
 
     // .debug
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("✅"))
@@ -167,39 +199,56 @@ func testConsoleOutputForExecutionOuput() async throws {
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("rc=0"))
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("retries=0"))
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("✅"))
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("uname"))
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("rc=0"))
     #expect(successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("retries=0"))
-    #expect(successResult.consoleOutput(verbosity: .debug(emoji: true)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("Darwin"))
+    #expect(successResult.consoleOutput(verbosity: .debug(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("I'm not telling you!"))
+    #expect(failureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("[00:00"))
+    // duration marker
 
     #expect(!failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("❌"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("uname"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("rc=-1"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("retries=0"))
     #expect(failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("I'm not telling you!"))
+    #expect(failureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: true)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(!ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("⚠️"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("uname"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("rc=-1"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("retries=0"))
     #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("I'm not telling you!"))
+    #expect(ignoreFailureResult.consoleOutput(verbosity: .debug(emoji: false)).contains("[00:00"))
+    // duration marker
 
     #expect(exceptionResult.consoleOutput(verbosity: .debug(emoji: true)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .debug(emoji: true)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .debug(emoji: true)).contains("[00:00"))
+    // duration marker
+
     #expect(!exceptionResult.consoleOutput(verbosity: .debug(emoji: false)).contains("🚫"))
     #expect(exceptionResult.consoleOutput(verbosity: .debug(emoji: false)).contains("exception reported"))
+    #expect(exceptionResult.consoleOutput(verbosity: .debug(emoji: false)).contains("[00:00"))
+    // duration marker
 }

--- a/Tests/formicTests/EngineTests.swift
+++ b/Tests/formicTests/EngineTests.swift
@@ -185,6 +185,8 @@ func testCommandTimeout() async throws {
     #expect(outputFromRun.representsFailure() == true)
     #expect(outputFromRun.output.stderrString == nil)
     #expect(outputFromRun.output.stdoutString == nil)
+    #expect(outputFromRun.duration > .seconds(1))
+    //print(outputFromRun.consoleOutput(verbosity: .debug(emoji: true)))
 }
 
 @Test("verify retry works as expected")


### PR DESCRIPTION
Shifting exception capture logic in engine.run(host, command) to allow for retries of failed commands and timeouts.

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `./scripts/preflight.bash` and it passed without errors.
